### PR TITLE
patch nodejs to use python2 instead of system "python"

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -16,6 +16,8 @@ nodejs = 0.10.25
 [nodejs]
 recipe = hexagonit.recipe.cmmi
 url = http://nodejs.org/dist/v${defined-versions:nodejs}/node-v${defined-versions:nodejs}.tar.gz
+patches = ${buildout:directory}/patches/0001-change-python-references-to-python2.patch
+patch-options = -p1
 strip-top-level-dir = true
 configure-options=
     --no-ssl2

--- a/patches/0001-change-python-references-to-python2.patch
+++ b/patches/0001-change-python-references-to-python2.patch
@@ -1,0 +1,1250 @@
+diff --git a/common.gypi b/common.gypi
+index 4193b5a..383b0af 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -9,7 +9,7 @@
+     'msvs_multi_core_compile': '0',  # we do enable multicore compiles, but not using the V8 way
+     'gcc_version%': 'unknown',
+     'clang%': 0,
+-    'python%': 'python',
++    'python%': 'python2',
+ 
+     # Turn on optimizations that may trigger compiler bugs.
+     # Use at your own risk. Do *NOT* report bugs if this option is enabled.
+diff --git a/configure b/configure
+index 72c3c5f..fcb3d19 100755
+--- a/configure
++++ b/configure
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ import optparse
+ import os
+ import pprint
+@@ -649,7 +649,7 @@ if (options.dest_os):
+ flavor = GetFlavor(flavor_params);
+ 
+ output = {
+-  'variables': { 'python': sys.executable },
++  'variables': { 'python2': sys.executable },
+   'include_dirs': [],
+   'libraries': [],
+   'defines': [],
+diff --git a/deps/cares/build/gcc_version.py b/deps/cares/build/gcc_version.py
+index da019e8..b4223af 100644
+--- a/deps/cares/build/gcc_version.py
++++ b/deps/cares/build/gcc_version.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ import os
+ import re
+diff --git a/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py b/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
+index 398eb87..3385c95 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
++++ b/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/deps/npm/node_modules/node-gyp/gyp/gyp_main.py b/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
+index 4ec872f..b0d148a 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
++++ b/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/gyptest.py b/deps/npm/node_modules/node-gyp/gyp/gyptest.py
+index a80dfbf..ee849d7 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/gyptest.py
++++ b/deps/npm/node_modules/node-gyp/gyp/gyptest.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings_test.py
+index 4e06da3..abec190 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/MSVSSettings_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
+index 30edea5..349a36a 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/common_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/common_test.py
+index ad6f9a1..bf0fa40 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/common_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/common_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/easy_xml_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/easy_xml_test.py
+index df64354..c8b594f 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/easy_xml_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/easy_xml_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
+index 3e7efff..342cb27 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs_test.py
+index c0b021d..0eb53ea 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py
+index 85d459e..0a51c4d 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py
+@@ -1606,7 +1606,7 @@ def _AddWinLinkRules(master_ninja, embed_manifest, link_incremental):
+       'exe': '1',
+       'dll': '2',
+     }[binary_type]
+-    return cmd % {'python': sys.executable,
++    return cmd % {'python2': sys.executable,
+                   'out': out,
+                   'ldcmd': ldcmd,
+                   'resname': resource_name}
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja_test.py
+index 52661bc..d013457 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py
+index 260324a..77a5687 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2013 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input_test.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input_test.py
+index cdbf6b2..414f8d4 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input_test.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright 2013 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
+index 20b3a48..7bced56 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
+index 3424c01..4693ce4 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/samples/samples b/deps/npm/node_modules/node-gyp/gyp/samples/samples
+index 804b618..0139666 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/samples/samples
++++ b/deps/npm/node_modules/node-gyp/gyp/samples/samples
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/setup.py b/deps/npm/node_modules/node-gyp/gyp/setup.py
+index 75a4255..e4ec8ba 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/setup.py
++++ b/deps/npm/node_modules/node-gyp/gyp/setup.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp b/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp
+index 29300fe..c10cdd1 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp
+@@ -987,7 +987,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/media/jni/media_player_listener_jni.h',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '<(DEPTH)/base/android/jni_generator/jni_generator.py',
+                 '-o',
+                 '<@(_inputs)',
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp.fontified b/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp.fontified
+index 962b7b2..0ef99fc 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp.fontified
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/emacs/testdata/media.gyp.fontified
+@@ -988,7 +988,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/media/jni/media_player_listener_jni.h',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '<(DEPTH)/base/android/jni_generator/jni_generator.py',
+                 '-o',
+                 '<@(_inputs)',
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py b/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
+index 326ae22..553a101 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
+index c51d358..262a0b3 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
+index 3195d85..e51c44f 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
+index 6099bd7..41530a8 100755
+--- a/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
++++ b/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/deps/npm/node_modules/node-gyp/lib/configure.js b/deps/npm/node_modules/node-gyp/lib/configure.js
+index e101a31..a48149e 100644
+--- a/deps/npm/node_modules/node-gyp/lib/configure.js
++++ b/deps/npm/node_modules/node-gyp/lib/configure.js
+@@ -22,7 +22,7 @@ exports.usage = 'Generates ' + (win ? 'MSVC project files' : 'a Makefile') + ' f
+ 
+ function configure (gyp, argv, callback) {
+ 
+-  var python = gyp.opts.python || process.env.PYTHON || 'python'
++  var python = gyp.opts.python || process.env.PYTHON || 'python2'
+     , buildDir = path.resolve('build')
+     , configNames = [ 'config.gypi', 'common.gypi' ]
+     , configs = []
+@@ -110,7 +110,7 @@ function configure (gyp, argv, callback) {
+ 
+   function getNodeDir () {
+ 
+-    // 'python' should be set by now
++    // 'python2' should be set by now
+     process.env.PYTHON = python
+ 
+     if (gyp.opts.nodedir) {
+diff --git a/deps/uv/gyp_uv.py b/deps/uv/gyp_uv.py
+index 4ba6916..1d059c1 100755
+--- a/deps/uv/gyp_uv.py
++++ b/deps/uv/gyp_uv.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ import glob
+ import platform
+diff --git a/deps/v8/build/gyp_v8 b/deps/v8/build/gyp_v8
+index 345f777..6324431 100755
+--- a/deps/v8/build/gyp_v8
++++ b/deps/v8/build/gyp_v8
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/src/d8.gyp b/deps/v8/src/d8.gyp
+index a8361e6..f65337c 100644
+--- a/deps/v8/src/d8.gyp
++++ b/deps/v8/src/d8.gyp
+@@ -99,7 +99,7 @@
+             '<(SHARED_INTERMEDIATE_DIR)/d8-js.cc',
+           ],
+           'action': [
+-            'python',
++            'python2',
+             '../tools/js2c.py',
+             '<@(_outputs)',
+             'D8',
+diff --git a/deps/v8/tools/android-run.py b/deps/v8/tools/android-run.py
+index 1693c5b..45db85a 100755
+--- a/deps/v8/tools/android-run.py
++++ b/deps/v8/tools/android-run.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/disasm.py b/deps/v8/tools/disasm.py
+index 681b425..63c782c 100644
+--- a/deps/v8/tools/disasm.py
++++ b/deps/v8/tools/disasm.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2011 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/gc-nvp-trace-processor.py b/deps/v8/tools/gc-nvp-trace-processor.py
+index fe5a7f3..daff955 100755
+--- a/deps/v8/tools/gc-nvp-trace-processor.py
++++ b/deps/v8/tools/gc-nvp-trace-processor.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/gen-postmortem-metadata.py b/deps/v8/tools/gen-postmortem-metadata.py
+index 7bee763..2542457 100644
+--- a/deps/v8/tools/gen-postmortem-metadata.py
++++ b/deps/v8/tools/gen-postmortem-metadata.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+diff --git a/deps/v8/tools/grokdump.py b/deps/v8/tools/grokdump.py
+index 46ead5e..3478bf5 100755
+--- a/deps/v8/tools/grokdump.py
++++ b/deps/v8/tools/grokdump.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/gyp/v8.gyp b/deps/v8/tools/gyp/v8.gyp
+index 7a54ef4..d9d0105 100644
+--- a/deps/v8/tools/gyp/v8.gyp
++++ b/deps/v8/tools/gyp/v8.gyp
+@@ -792,7 +792,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/libraries.cc',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '../../tools/js2c.py',
+                 '<@(_outputs)',
+                 'CORE',
+@@ -810,7 +810,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/experimental-libraries.cc',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '../../tools/js2c.py',
+                 '<@(_outputs)',
+                 'EXPERIMENTAL',
+@@ -840,7 +840,7 @@
+                   '<(SHARED_INTERMEDIATE_DIR)/debug-support.cc',
+                 ],
+                 'action': [
+-                  'python',
++                  'python2',
+                   '../../tools/gen-postmortem-metadata.py',
+                   '<@(_outputs)',
+                   '<@(heapobject_files)'
+diff --git a/deps/v8/tools/js2c.py b/deps/v8/tools/js2c.py
+index d06cbe4..fb36645 100644
+--- a/deps/v8/tools/js2c.py
++++ b/deps/v8/tools/js2c.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/jsmin.py b/deps/v8/tools/jsmin.py
+index 250dea9..a2ea0ad 100644
+--- a/deps/v8/tools/jsmin.py
++++ b/deps/v8/tools/jsmin.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python2.4
++#!/usr/bin/python2
+ 
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/ll_prof.py b/deps/v8/tools/ll_prof.py
+index 3afe179..1ab49c6 100755
+--- a/deps/v8/tools/ll_prof.py
++++ b/deps/v8/tools/ll_prof.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/presubmit.py b/deps/v8/tools/presubmit.py
+index efa8724..37914d9 100755
+--- a/deps/v8/tools/presubmit.py
++++ b/deps/v8/tools/presubmit.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+@@ -240,7 +240,7 @@ class CppLintProcessor(SourceFileProcessor):
+     command = ['cpplint.py', '--filter', filt]
+     local_cpplint = join(path, "tools", "cpplint.py")
+     if exists(local_cpplint):
+-      command = ['python', local_cpplint, '--filter', filt]
++      command = ['python2', local_cpplint, '--filter', filt]
+ 
+     commands = join([command + [file] for file in files])
+     count = multiprocessing.cpu_count()
+diff --git a/deps/v8/tools/process-heap-prof.py b/deps/v8/tools/process-heap-prof.py
+index a26cbf1..c7a4e6e 100755
+--- a/deps/v8/tools/process-heap-prof.py
++++ b/deps/v8/tools/process-heap-prof.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2009 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/run-tests.py b/deps/v8/tools/run-tests.py
+index a1de3dc..82f0be3 100755
+--- a/deps/v8/tools/run-tests.py
++++ b/deps/v8/tools/run-tests.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/run-valgrind.py b/deps/v8/tools/run-valgrind.py
+index 49c1b70..067c326 100755
+--- a/deps/v8/tools/run-valgrind.py
++++ b/deps/v8/tools/run-valgrind.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2
+ #
+ # Copyright 2009 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/stats-viewer.py b/deps/v8/tools/stats-viewer.py
+index ab8e287..702151d 100755
+--- a/deps/v8/tools/stats-viewer.py
++++ b/deps/v8/tools/stats-viewer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/status-file-converter.py b/deps/v8/tools/status-file-converter.py
+index ba063ee..3c94736 100755
+--- a/deps/v8/tools/status-file-converter.py
++++ b/deps/v8/tools/status-file-converter.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/test-server.py b/deps/v8/tools/test-server.py
+index df547ed..d796ed2 100755
+--- a/deps/v8/tools/test-server.py
++++ b/deps/v8/tools/test-server.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/test-wrapper-gypbuild.py b/deps/v8/tools/test-wrapper-gypbuild.py
+index 4dd6338..7ea1772 100755
+--- a/deps/v8/tools/test-wrapper-gypbuild.py
++++ b/deps/v8/tools/test-wrapper-gypbuild.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/test.py b/deps/v8/tools/test.py
+index b3b62b3..6f1a972 100755
+--- a/deps/v8/tools/test.py
++++ b/deps/v8/tools/test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2012 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/deps/v8/tools/testrunner/server/daemon.py b/deps/v8/tools/testrunner/server/daemon.py
+index baa66fb..26a58c8 100644
+--- a/deps/v8/tools/testrunner/server/daemon.py
++++ b/deps/v8/tools/testrunner/server/daemon.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # This code has been written by Sander Marechal and published at:
+ # http://www.jejik.com/articles/2007/02/a_simple_unix_linux_daemon_in_python/
+diff --git a/test/pummel/test-child-process-spawn-loop.js b/test/pummel/test-child-process-spawn-loop.js
+index 631d9fc..a9a11be 100644
+--- a/test/pummel/test-child-process-spawn-loop.js
++++ b/test/pummel/test-child-process-spawn-loop.js
+@@ -34,7 +34,7 @@ var N = 40;
+ var finished = false;
+ 
+ function doSpawn(i) {
+-  var child = spawn('python', ['-c', 'print ' + SIZE + ' * "C"']);
++  var child = spawn('python2', ['-c', 'print ' + SIZE + ' * "C"']);
+   var count = 0;
+ 
+   child.stdout.setEncoding('ascii');
+diff --git a/test/pummel/test-exec.js b/test/pummel/test-exec.js
+index 6eacda7..74be6cd 100644
+--- a/test/pummel/test-exec.js
++++ b/test/pummel/test-exec.js
+@@ -110,7 +110,7 @@ function killMeTwiceCallback(err, stdout, stderr) {
+ }
+ 
+ 
+-exec('python -c "print 200000*\'C\'"', {maxBuffer: 1000},
++exec('python2 -c "print 200000*\'C\'"', {maxBuffer: 1000},
+      function(err, stdout, stderr) {
+        assert.ok(err);
+        assert.ok(/maxBuffer/.test(err.message));
+diff --git a/test/simple/test-child-process-set-blocking.js b/test/simple/test-child-process-set-blocking.js
+index 030b682..14db415 100644
+--- a/test/simple/test-child-process-set-blocking.js
++++ b/test/simple/test-child-process-set-blocking.js
+@@ -26,7 +26,7 @@ var ch = require('child_process');
+ var SIZE = 100000;
+ var childGone = false;
+ 
+-var cp = ch.spawn('python', ['-c', 'print ' + SIZE + ' * "C"'], {
++var cp = ch.spawn('python2', ['-c', 'print ' + SIZE + ' * "C"'], {
+   customFds: [0, 1, 2]
+ });
+ 
+diff --git a/tools/closure_linter/closure_linter/__init__.py b/tools/closure_linter/closure_linter/__init__.py
+index 4265cc3..18ff536 100755
+--- a/tools/closure_linter/closure_linter/__init__.py
++++ b/tools/closure_linter/closure_linter/__init__.py
+@@ -1 +1 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+diff --git a/tools/closure_linter/closure_linter/checker.py b/tools/closure_linter/closure_linter/checker.py
+index 4cdac93..ba76df2 100755
+--- a/tools/closure_linter/closure_linter/checker.py
++++ b/tools/closure_linter/closure_linter/checker.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/checkerbase.py b/tools/closure_linter/closure_linter/checkerbase.py
+index 123cb72..f59f0bb 100755
+--- a/tools/closure_linter/closure_linter/checkerbase.py
++++ b/tools/closure_linter/closure_linter/checkerbase.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/__init__.py b/tools/closure_linter/closure_linter/common/__init__.py
+index 4265cc3..18ff536 100755
+--- a/tools/closure_linter/closure_linter/common/__init__.py
++++ b/tools/closure_linter/closure_linter/common/__init__.py
+@@ -1 +1 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+diff --git a/tools/closure_linter/closure_linter/common/error.py b/tools/closure_linter/closure_linter/common/error.py
+index 0e3b476..83e9bcf 100755
+--- a/tools/closure_linter/closure_linter/common/error.py
++++ b/tools/closure_linter/closure_linter/common/error.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/erroraccumulator.py b/tools/closure_linter/closure_linter/common/erroraccumulator.py
+index 7bb0c97..3b1ec7a 100755
+--- a/tools/closure_linter/closure_linter/common/erroraccumulator.py
++++ b/tools/closure_linter/closure_linter/common/erroraccumulator.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/errorhandler.py b/tools/closure_linter/closure_linter/common/errorhandler.py
+index 764d54d..8ee08fa 100755
+--- a/tools/closure_linter/closure_linter/common/errorhandler.py
++++ b/tools/closure_linter/closure_linter/common/errorhandler.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/errorprinter.py b/tools/closure_linter/closure_linter/common/errorprinter.py
+index c975406..ed8eaaf 100755
+--- a/tools/closure_linter/closure_linter/common/errorprinter.py
++++ b/tools/closure_linter/closure_linter/common/errorprinter.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/filetestcase.py b/tools/closure_linter/closure_linter/common/filetestcase.py
+index ae4b883..245436d 100755
+--- a/tools/closure_linter/closure_linter/common/filetestcase.py
++++ b/tools/closure_linter/closure_linter/common/filetestcase.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/htmlutil.py b/tools/closure_linter/closure_linter/common/htmlutil.py
+index 26d44c5..c8a215c 100755
+--- a/tools/closure_linter/closure_linter/common/htmlutil.py
++++ b/tools/closure_linter/closure_linter/common/htmlutil.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/lintrunner.py b/tools/closure_linter/closure_linter/common/lintrunner.py
+index 07842c7..eb40193 100755
+--- a/tools/closure_linter/closure_linter/common/lintrunner.py
++++ b/tools/closure_linter/closure_linter/common/lintrunner.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/matcher.py b/tools/closure_linter/closure_linter/common/matcher.py
+index 9b4402c..182a120 100755
+--- a/tools/closure_linter/closure_linter/common/matcher.py
++++ b/tools/closure_linter/closure_linter/common/matcher.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/position.py b/tools/closure_linter/closure_linter/common/position.py
+index cebf17e..fef9ca7 100755
+--- a/tools/closure_linter/closure_linter/common/position.py
++++ b/tools/closure_linter/closure_linter/common/position.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/simplefileflags.py b/tools/closure_linter/closure_linter/common/simplefileflags.py
+index 3402bef..844241c 100755
+--- a/tools/closure_linter/closure_linter/common/simplefileflags.py
++++ b/tools/closure_linter/closure_linter/common/simplefileflags.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/tokenizer.py b/tools/closure_linter/closure_linter/common/tokenizer.py
+index 0234720..223d22b 100755
+--- a/tools/closure_linter/closure_linter/common/tokenizer.py
++++ b/tools/closure_linter/closure_linter/common/tokenizer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/common/tokens.py b/tools/closure_linter/closure_linter/common/tokens.py
+index 5eaffa8..95ab42f 100755
+--- a/tools/closure_linter/closure_linter/common/tokens.py
++++ b/tools/closure_linter/closure_linter/common/tokens.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/ecmalintrules.py b/tools/closure_linter/closure_linter/ecmalintrules.py
+index a971b44..901ebe8 100755
+--- a/tools/closure_linter/closure_linter/ecmalintrules.py
++++ b/tools/closure_linter/closure_linter/ecmalintrules.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/ecmametadatapass.py b/tools/closure_linter/closure_linter/ecmametadatapass.py
+index 2c797b3..8fc06a5 100755
+--- a/tools/closure_linter/closure_linter/ecmametadatapass.py
++++ b/tools/closure_linter/closure_linter/ecmametadatapass.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/error_fixer.py b/tools/closure_linter/closure_linter/error_fixer.py
+index 904cf86..baeb278 100755
+--- a/tools/closure_linter/closure_linter/error_fixer.py
++++ b/tools/closure_linter/closure_linter/error_fixer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/errorrules.py b/tools/closure_linter/closure_linter/errorrules.py
+index afb6fa9..dad0aef 100755
+--- a/tools/closure_linter/closure_linter/errorrules.py
++++ b/tools/closure_linter/closure_linter/errorrules.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/errors.py b/tools/closure_linter/closure_linter/errors.py
+index 7c86941..cfadaa8 100755
+--- a/tools/closure_linter/closure_linter/errors.py
++++ b/tools/closure_linter/closure_linter/errors.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/fixjsstyle.py b/tools/closure_linter/closure_linter/fixjsstyle.py
+index 8782e64..ba89be2 100755
+--- a/tools/closure_linter/closure_linter/fixjsstyle.py
++++ b/tools/closure_linter/closure_linter/fixjsstyle.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/fixjsstyle_test.py b/tools/closure_linter/closure_linter/fixjsstyle_test.py
+index 42e9c59..2d1e9ff 100755
+--- a/tools/closure_linter/closure_linter/fixjsstyle_test.py
++++ b/tools/closure_linter/closure_linter/fixjsstyle_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/full_test.py b/tools/closure_linter/closure_linter/full_test.py
+index f11f235..68ef48a 100755
+--- a/tools/closure_linter/closure_linter/full_test.py
++++ b/tools/closure_linter/closure_linter/full_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/gjslint.py b/tools/closure_linter/closure_linter/gjslint.py
+index e33bddd..b807ea7 100755
+--- a/tools/closure_linter/closure_linter/gjslint.py
++++ b/tools/closure_linter/closure_linter/gjslint.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/indentation.py b/tools/closure_linter/closure_linter/indentation.py
+index d740607..d162ea7 100755
+--- a/tools/closure_linter/closure_linter/indentation.py
++++ b/tools/closure_linter/closure_linter/indentation.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/javascriptlintrules.py b/tools/closure_linter/closure_linter/javascriptlintrules.py
+index 6b9f1be..045b9c4 100755
+--- a/tools/closure_linter/closure_linter/javascriptlintrules.py
++++ b/tools/closure_linter/closure_linter/javascriptlintrules.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/javascriptstatetracker.py b/tools/closure_linter/closure_linter/javascriptstatetracker.py
+index 9cce376..bd39000 100755
+--- a/tools/closure_linter/closure_linter/javascriptstatetracker.py
++++ b/tools/closure_linter/closure_linter/javascriptstatetracker.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/javascriptstatetracker_test.py b/tools/closure_linter/closure_linter/javascriptstatetracker_test.py
+index e4288b7..300e0ac 100755
+--- a/tools/closure_linter/closure_linter/javascriptstatetracker_test.py
++++ b/tools/closure_linter/closure_linter/javascriptstatetracker_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/javascripttokenizer.py b/tools/closure_linter/closure_linter/javascripttokenizer.py
+index 097d3fd..ff0080e 100755
+--- a/tools/closure_linter/closure_linter/javascripttokenizer.py
++++ b/tools/closure_linter/closure_linter/javascripttokenizer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/javascripttokens.py b/tools/closure_linter/closure_linter/javascripttokens.py
+index f46d4e1..e7646a3 100755
+--- a/tools/closure_linter/closure_linter/javascripttokens.py
++++ b/tools/closure_linter/closure_linter/javascripttokens.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/statetracker.py b/tools/closure_linter/closure_linter/statetracker.py
+index 5630c17..2c3e1c5 100755
+--- a/tools/closure_linter/closure_linter/statetracker.py
++++ b/tools/closure_linter/closure_linter/statetracker.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/closure_linter/tokenutil.py b/tools/closure_linter/closure_linter/tokenutil.py
+index 6ed5f7f..5cce8b6 100755
+--- a/tools/closure_linter/closure_linter/tokenutil.py
++++ b/tools/closure_linter/closure_linter/tokenutil.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2007 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/closure_linter/gflags.py b/tools/closure_linter/gflags.py
+index 21aa88e..c970c0d 100644
+--- a/tools/closure_linter/gflags.py
++++ b/tools/closure_linter/gflags.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2007, Google Inc.
+ # All rights reserved.
+diff --git a/tools/closure_linter/setup.py b/tools/closure_linter/setup.py
+index 1d1764f..c829138 100755
+--- a/tools/closure_linter/setup.py
++++ b/tools/closure_linter/setup.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2010 The Closure Linter Authors. All Rights Reserved.
+ #
+diff --git a/tools/cpplint.py b/tools/cpplint.py
+index d7c8e71..49b496b 100644
+--- a/tools/cpplint.py
++++ b/tools/cpplint.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python2.4
++#!/usr/bin/python2
+ #
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ #
+diff --git a/tools/genv8constants.py b/tools/genv8constants.py
+index 45b4ae3..f2542a9 100755
+--- a/tools/genv8constants.py
++++ b/tools/genv8constants.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ #
+ # genv8constants.py output_file libv8_base.a
+diff --git a/tools/gyp/buildbot/buildbot_run.py b/tools/gyp/buildbot/buildbot_run.py
+index 979073c..07ae2fa 100755
+--- a/tools/gyp/buildbot/buildbot_run.py
++++ b/tools/gyp/buildbot/buildbot_run.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/tools/gyp/gyp_main.py b/tools/gyp/gyp_main.py
+index 4ec872f..b0d148a 100755
+--- a/tools/gyp/gyp_main.py
++++ b/tools/gyp/gyp_main.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/gyptest.py b/tools/gyp/gyptest.py
+index 8f3ee0f..090b9ac 100755
+--- a/tools/gyp/gyptest.py
++++ b/tools/gyp/gyptest.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/MSVSSettings_test.py b/tools/gyp/pylib/gyp/MSVSSettings_test.py
+index 4e06da3..abec190 100755
+--- a/tools/gyp/pylib/gyp/MSVSSettings_test.py
++++ b/tools/gyp/pylib/gyp/MSVSSettings_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/__init__.py b/tools/gyp/pylib/gyp/__init__.py
+index 30edea5..349a36a 100755
+--- a/tools/gyp/pylib/gyp/__init__.py
++++ b/tools/gyp/pylib/gyp/__init__.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/common_test.py b/tools/gyp/pylib/gyp/common_test.py
+index ad6f9a1..bf0fa40 100755
+--- a/tools/gyp/pylib/gyp/common_test.py
++++ b/tools/gyp/pylib/gyp/common_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/easy_xml_test.py b/tools/gyp/pylib/gyp/easy_xml_test.py
+index df64354..c8b594f 100755
+--- a/tools/gyp/pylib/gyp/easy_xml_test.py
++++ b/tools/gyp/pylib/gyp/easy_xml_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/flock_tool.py b/tools/gyp/pylib/gyp/flock_tool.py
+index 3e7efff..342cb27 100755
+--- a/tools/gyp/pylib/gyp/flock_tool.py
++++ b/tools/gyp/pylib/gyp/flock_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/tools/gyp/pylib/gyp/generator/msvs_test.py b/tools/gyp/pylib/gyp/generator/msvs_test.py
+index c0b021d..0eb53ea 100755
+--- a/tools/gyp/pylib/gyp/generator/msvs_test.py
++++ b/tools/gyp/pylib/gyp/generator/msvs_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/tools/gyp/pylib/gyp/generator/ninja.py b/tools/gyp/pylib/gyp/generator/ninja.py
+index 7461814..93d1d2c 100644
+--- a/tools/gyp/pylib/gyp/generator/ninja.py
++++ b/tools/gyp/pylib/gyp/generator/ninja.py
+@@ -1600,7 +1600,7 @@ def _AddWinLinkRules(master_ninja, embed_manifest):
+     return '%(python)s gyp-win-tool link-with-manifests $arch %(embed)s ' \
+            '%(out)s "%(ldcmd)s" %(resname)s $mt $rc "$intermediatemanifest" ' \
+            '$manifests' % {
+-               'python': sys.executable,
++               'python2': sys.executable,
+                'out': out,
+                'ldcmd': ldcmd,
+                'resname': resource_name,
+diff --git a/tools/gyp/pylib/gyp/generator/ninja_test.py b/tools/gyp/pylib/gyp/generator/ninja_test.py
+index 52661bc..d013457 100644
+--- a/tools/gyp/pylib/gyp/generator/ninja_test.py
++++ b/tools/gyp/pylib/gyp/generator/ninja_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/generator/xcode_test.py b/tools/gyp/pylib/gyp/generator/xcode_test.py
+index 260324a..77a5687 100644
+--- a/tools/gyp/pylib/gyp/generator/xcode_test.py
++++ b/tools/gyp/pylib/gyp/generator/xcode_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2013 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/input_test.py b/tools/gyp/pylib/gyp/input_test.py
+index cdbf6b2..414f8d4 100755
+--- a/tools/gyp/pylib/gyp/input_test.py
++++ b/tools/gyp/pylib/gyp/input_test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright 2013 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/pylib/gyp/mac_tool.py b/tools/gyp/pylib/gyp/mac_tool.py
+index ac19b6d..d4ef7b7 100755
+--- a/tools/gyp/pylib/gyp/mac_tool.py
++++ b/tools/gyp/pylib/gyp/mac_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+diff --git a/tools/gyp/pylib/gyp/win_tool.py b/tools/gyp/pylib/gyp/win_tool.py
+index e9d7df0..d2e964f 100755
+--- a/tools/gyp/pylib/gyp/win_tool.py
++++ b/tools/gyp/pylib/gyp/win_tool.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+@@ -130,7 +130,7 @@ class WinTool(object):
+     # first and only link. We still tell link to generate a manifest, but we
+     # only use that to assert that our simpler process did not miss anything.
+     variables = {
+-      'python': sys.executable,
++      'python2': sys.executable,
+       'arch': arch,
+       'out': out,
+       'ldcmd': ldcmd,
+diff --git a/tools/gyp/samples/samples b/tools/gyp/samples/samples
+index 804b618..0139666 100755
+--- a/tools/gyp/samples/samples
++++ b/tools/gyp/samples/samples
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/setup.py b/tools/gyp/setup.py
+index 75a4255..e4ec8ba 100755
+--- a/tools/gyp/setup.py
++++ b/tools/gyp/setup.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2009 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/tools/emacs/testdata/media.gyp b/tools/gyp/tools/emacs/testdata/media.gyp
+index 29300fe..c10cdd1 100644
+--- a/tools/gyp/tools/emacs/testdata/media.gyp
++++ b/tools/gyp/tools/emacs/testdata/media.gyp
+@@ -987,7 +987,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/media/jni/media_player_listener_jni.h',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '<(DEPTH)/base/android/jni_generator/jni_generator.py',
+                 '-o',
+                 '<@(_inputs)',
+diff --git a/tools/gyp/tools/emacs/testdata/media.gyp.fontified b/tools/gyp/tools/emacs/testdata/media.gyp.fontified
+index 962b7b2..0ef99fc 100644
+--- a/tools/gyp/tools/emacs/testdata/media.gyp.fontified
++++ b/tools/gyp/tools/emacs/testdata/media.gyp.fontified
+@@ -988,7 +988,7 @@
+                 '<(SHARED_INTERMEDIATE_DIR)/media/jni/media_player_listener_jni.h',
+               ],
+               'action': [
+-                'python',
++                'python2',
+                 '<(DEPTH)/base/android/jni_generator/jni_generator.py',
+                 '-o',
+                 '<@(_inputs)',
+diff --git a/tools/gyp/tools/graphviz.py b/tools/gyp/tools/graphviz.py
+index 326ae22..553a101 100755
+--- a/tools/gyp/tools/graphviz.py
++++ b/tools/gyp/tools/graphviz.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2011 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/tools/pretty_gyp.py b/tools/gyp/tools/pretty_gyp.py
+index c51d358..262a0b3 100755
+--- a/tools/gyp/tools/pretty_gyp.py
++++ b/tools/gyp/tools/pretty_gyp.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/tools/pretty_sln.py b/tools/gyp/tools/pretty_sln.py
+index 3195d85..e51c44f 100755
+--- a/tools/gyp/tools/pretty_sln.py
++++ b/tools/gyp/tools/pretty_sln.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp/tools/pretty_vcproj.py b/tools/gyp/tools/pretty_vcproj.py
+index 6099bd7..41530a8 100755
+--- a/tools/gyp/tools/pretty_vcproj.py
++++ b/tools/gyp/tools/pretty_vcproj.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ # Copyright (c) 2012 Google Inc. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+diff --git a/tools/gyp_node.py b/tools/gyp_node.py
+index 7b49505..69d614f 100755
+--- a/tools/gyp_node.py
++++ b/tools/gyp_node.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ import glob
+ import os
+ import shlex
+diff --git a/tools/install.py b/tools/install.py
+index 7249de3..65f2c44 100755
+--- a/tools/install.py
++++ b/tools/install.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ 
+ import errno
+ 
+diff --git a/tools/js2c.py b/tools/js2c.py
+index 772a0f5..b70b62e 100755
+--- a/tools/js2c.py
++++ b/tools/js2c.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2006-2008 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+diff --git a/tools/test.py b/tools/test.py
+index c922c40..426574b 100755
+--- a/tools/test.py
++++ b/tools/test.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ #
+ # Copyright 2008 the V8 project authors. All rights reserved.
+ # Redistribution and use in source and binary forms, with or without
+-- 
+1.9.0
+


### PR DESCRIPTION
system "python" may refer to either python2 or python3 and nodejs will fail to
compile if it is python3

see http://legacy.python.org/dev/peps/pep-0394/