### PR TITLE
don't use group_by on information_schema.tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 unreleased
 ==========
 
+ - Changed query to fetch table information. Group by wasn't necessary and sum
+   on number_of_replicas won't work in the next crate version as it is changed
+   to a string.
 
 2014/03/07 0.2.4
 ================

--- a/app/js/tables.js
+++ b/app/js/tables.js
@@ -148,10 +148,9 @@ define(['jquery',
 
             d = $.Deferred();
             sqInfo = new SQL.Query(
-                'select table_name, sum(number_of_shards), sum(number_of_replicas) ' +
+                'select table_name, number_of_shards, number_of_replicas ' +
                 'from information_schema.tables ' +
-                'where schema_name = \'doc\'' +
-                'group by table_name');
+                'where schema_name = \'doc\'');
 
             sqShardInfo = new SQL.Query(
                 'select table_name, sum(num_docs), "primary", avg(num_docs), count(*), state, sum(size) '+


### PR DESCRIPTION
granularity is table_name anyway so group by isn't necessary and
sum(number_of_replicas) won't work with the next crate version as it is
changed to a string.
