### PR TITLE
Update year in copyright license: Trello #693

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Crate Admin Interface
-Copyright 2013-2014 CRATE Technology GmbH ("Crate")
+Copyright 2013-2015 CRATE Technology GmbH ("Crate")
 
 
 Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Crate Admin Interface
-Copyright 2013-2014 CRATE Technology GmbH
+Copyright 2013-2015 CRATE Technology GmbH
 
 Third party dependencies:
 


### PR DESCRIPTION
The year needed to be updated in the license file from 2014 to 2015.