### PR TITLE
show relative Crate process CPU usage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - display relative Crate process CPU usage as bar chart
+   and show number of cores per node
+
 2015/08/06 0.14.3
 =================
 

--- a/app/scripts/controllers/cluster.js
+++ b/app/scripts/controllers/cluster.js
@@ -294,6 +294,19 @@ angular.module('cluster', ['stats', 'sql', 'common', 'nodeinfo'])
           "color": COLORS.free
         }
       ];
+
+      $scope.processCpuData = [
+        {
+          "key": "Used",
+          "values": [["Process CPU", Math.min(100.0, node.proc_cpu.percent / node.num_cores)]],
+          "color": COLORS.used
+        },
+        {
+          "key": "Idle",
+          "values": [["Process CPU", Math.max(0, 100.0 - node.proc_cpu.percent / node.num_cores)]],
+          "color": COLORS.free
+        }
+      ];
     }
 
     // bind tooltips

--- a/app/scripts/services/stats.js
+++ b/app/scripts/services/stats.js
@@ -155,13 +155,13 @@ angular.module('stats', ['sql', 'health', 'tableinfo'])
     var refreshState = function() {
       if (!data.online) return;
 
-      var clusterQuery = SQLQuery.execute(
+      var sysNodesQuery = SQLQuery.execute(
         'select id, name, hostname, rest_url, port, load, heap, fs, os[\'cpu\'] as cpu, load, version, os[\'probe_timestamp\'] as timestamp, ' +
-        'process[\'cpu\'] as proc_cpu ' +
+        'process[\'cpu\'] as proc_cpu, os_info[\'available_processors\'] as num_cores ' +
         'from sys.nodes');
-      clusterQuery.success(function(sqlQuery) {
+      sysNodesQuery.success(function(sqlQuery) {
         var response = queryResultToObjects(sqlQuery,
-            ['id', 'name', 'hostname', 'rest_url', 'port', 'load', 'heap', 'fs', 'cpu', 'load', 'version', 'timestamp', 'proc_cpu']);
+            ['id', 'name', 'hostname', 'rest_url', 'port', 'load', 'heap', 'fs', 'cpu', 'load', 'version', 'timestamp', 'proc_cpu', 'num_cores']);
         data.load = prepareLoadInfo(response);
         data.cluster = prepareIoStats(response);
       }).error(onErrorResponse);

--- a/app/styles/theme.less
+++ b/app/styles/theme.less
@@ -379,6 +379,11 @@ h2, h3 {
   font-size: @font-size-large;
 }
 
+.announcement-heading.small {
+  font-size: @font-size-small;
+}
+
+
 .announcement-text {
   font-size: @font-size-small;
   color: @gray-light;

--- a/app/views/node.html
+++ b/app/views/node.html
@@ -86,9 +86,9 @@
       </div>
 
       <div class="row">
-        <div class="col-sm-6 col-xs-12">
-          <h3 class="panel-headline">Load</h3>
+        <div class="col-sm-4 col-xs-8">
           <div class="panel">
+            <h3 class="panel-headline">Load</h3>
             <p class="announcement-heading" ng-show="node.load['1'] >= 0">
               <span class="load-value">{{ node.load['1']|number:2 }}</span>
               <span class="load-value">{{ node.load['5']|number:2 }}</span>
@@ -102,16 +102,35 @@
             </p>
           </div>
         </div>
-        <div class="col-sm-6 col-xs-12">
-          <h3 class="panel-headline">Crate Process</h3>
+        <div class="col-sm-2 col-xs-4">
           <div class="panel">
-            <p class="announcement-heading" ng-show="node.proc_cpu.percent >= 0">{{ node.proc_cpu.percent|number:1 }}%</p>
-            <p class="announcement-heading" ng-hide="node.proc_cpu.percent >= 0">-</p>
-            <p class="announcement-text">CPU Usage</p>
+            <h3 class="panel-headline">CPU Cores</h3>
+            <p class="announcement-heading" ng-show="node.num_cores > 0">
+              <span class="load-value">{{ node.num_cores }}</span>
+            </p>
+            <p class="announcement-heading" ng-hide="node.num_cores > 0">-</p>
+            <p class="announcement-text">
+              <span class="load-label">Cores</span>
+            </p>
+          </div>
+        </div>
+        <div class="col-sm-6 col-xs-12">
+          <div class="panel">
+            <h3 class="panel-headline">Crate Process</h3>
+            <div class="chart-container">
+              <nvd3-multi-bar-horizontal-chart id="chart-process-cpu"
+                data="processCpuData"
+                height="20"
+                margin="{left: 0, top: 0, bottom: 0, right: 0}"
+                stacked="true"
+                tooltips="true"
+                tooltipcontent="toolTipUsedPercentFunction()">
+              </nvd3-multi-bar-horizontal-chart>
+            </div>
           </div>
         </div>
       </div>
-      
+
       <div class="row">
         <div class="col-sm-12">
           <h3 class="panel-headline">Shards</h3>
@@ -145,7 +164,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="row">
         <div class="col-sm-12">
           <h3 class="panel-headline">Disk Operations</h3>


### PR DESCRIPTION
and display number of cores per node

Note: this feature will require Crate 0.52.x