### PR TITLE
UDC: identify anonymous user with cluster id.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - UDC: identify anonymous user with cluster id.
+   Both user id and cluster id are anonymous traits.
+   Note: You can disable UDC via the `udc.enabled` setting on the Crate server.
+
 2015/10/30 0.15.3
 =================
 

--- a/app/scripts/controllers/common.js
+++ b/app/scripts/controllers/common.js
@@ -102,12 +102,12 @@ var commons = angular.module('common', ['stats', 'udc'])
   })
 .controller('HelpMenuController', function ($scope, UidLoader, UdcSettings) {
   var verified = null;
-  
+
   // set user
   $scope.user = {
     uid: null
   };
-  
+
   // 'analytics' is globally available
   analytics.load(UdcSettings.SegmentIoToken)
   analytics.ready(function(){
@@ -117,22 +117,25 @@ var commons = angular.module('common', ['stats', 'udc'])
       traits: user.traits()
     };
   });
-  
-  var identify = function identify(user){
-    if (user.uid != null) {
-      analytics.setAnonymousId(user.uid);
-      // check for messsages
+
+  var identify = function identify(userdata){
+    if (userdata.user.uid != null) {
+      analytics.setAnonymousId(userdata.user.uid);
+      analytics.identify(userdata.user.uid);
       analytics.page();
-      analytics.track('visited_admin', { version: $scope.version.number});
+      analytics.track('visited_admin', {
+        'version': $scope.version.number,
+        'cluster_id': userdata.cluster_id
+      });
     }
   };
 
-  UdcSettings.availability.success(function(isEnabled){
-    if (isEnabled === true) {
+  UdcSettings.availability.success(function(data){
+    if (data.enabled === true) {
       // load uid
       UidLoader.load().success(function(uid){
         $scope.user.uid = uid.toString();
-        identify($scope.user);
+        identify({'user': $scope.user, 'cluster_id': data.cluster_id});
       }).error(function(error){
         console.warn(error);
       });

--- a/app/scripts/services/udc.js
+++ b/app/scripts/services/udc.js
@@ -14,13 +14,13 @@ angular.module('udc', [])
       return promise;
     };
 
-    var stmt = "SELECT settings['udc']['enabled'] as enabled from sys.cluster";
+    var stmt = "SELECT settings['udc']['enabled'] as enabled, id as cluster_id from sys.cluster";
     var UdcSettingsQuery = SQLQuery.execute(stmt);
     UdcSettingsQuery.success(function(query) {
-      var result = queryResultToObjects(query, ['enabled']);
-      deferred.resolve(result[0]['enabled']);
+      var result = queryResultToObjects(query, ['enabled','cluster_id']);
+      deferred.resolve(result[0]);
     }).error(function(query) { deferred.reject(null, "could not load udc setting"); });
-    
+
     return {
       SegmentIoToken: 'sfTz0KpAhR0KmOH4GnoqbpLID71eaB3w',
       availability: promise


### PR DESCRIPTION
Both user id and cluster id are anonymous traits.
You can disable UDC via the `udc.enabled` setting on the Crate server.