### PR TITLE
version check was always fetched with `udc.enabled=false`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - fix: Crate version check was always fetched with `udc.enabled=false`
+   even when the `udc.enabled` setting was enabled on the Crate server.
+
  - fix: charts are not correctly displayed in Microsoft Edge browser.
 
  - UDC: identify anonymous user with cluster id.

--- a/app/scripts/controllers/feed.js
+++ b/app/scripts/controllers/feed.js
@@ -32,24 +32,24 @@ angular.module('feed', ['stats'])
     var BLOG_URL = 'https://crate.io/blog/category/developernews';
     var MAX_ITEMS = 5;
     var VERSION_URL = 'https://crate.io/versions.json';
-    
-    UdcSettings.availability.success(function(isEnabled) {
-      if (isEnabled !== true) {
+
+    UdcSettings.availability.success(function(data) {
+      if (data.enabled !== true) {
         var udcString = '?udc.enabled=false';
         BLOG_URL = BLOG_URL.concat(udcString);
         VERSION_URL = VERSION_URL.concat(udcString);
       }
-      
+
       $scope.showUpdate = false;
       $scope.numUnread = 0;
       $scope.entries = [];
       $scope.blog_url = BLOG_URL;
-      
+
       var stableVersion;
       $http.get(VERSION_URL, { withCredentials: true }).success(function(response){
         if (response && response.crate) stableVersion = response.crate;
       });
-      
+
       $scope.$watch(function(){ return ClusterState.data; }, function(data) {
         $scope.showUpdate = data.version && stableVersion && stableVersion > data.version.number;
         $scope.stableVersion = stableVersion;
@@ -61,7 +61,7 @@ angular.module('feed', ['stats'])
       $scope.isRead = isRead;
       $scope.markAsRead = markAsRead;
     });
-    
+
     var markAsRead = function markAsRead(item){
       if (item === 'all') {
         var all = $scope.entries;
@@ -83,7 +83,7 @@ angular.module('feed', ['stats'])
       }
       return false;
     };
-    
+
     FeedService.parse(BLOG_URL, MAX_ITEMS).then(function(result){
       var trunc = $filter('characters');
       if (result.status === 200 && result.data.length > 0) {


### PR DESCRIPTION
even when the `udc.enabled` setting was enabled on the Crate server