### PR TITLE
fix: column headers where not shown in result table on console page

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,9 +5,12 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
- - displays current shard recovery status on table info page. It shows the 
+ - fix: column headers where not shown in result table on console page
+   when two or more columns with the same name were selected
+
+ - Display current shard recovery status on table info page. It shows the
    percentage of done recovery.
- 
+
  - Updated calculation of underreplicated shards/records to work with the
    change in Crate server where shards in sys.shards table have a more fine
    granular state now and relocating shards are listed, too.

--- a/app/scripts/controllers/console.js
+++ b/app/scripts/controllers/console.js
@@ -22,7 +22,6 @@ angular.module('console', ['sql'])
           message: ''
         };
 
-
         this.setInputScope = function(scope) {
           inputScope = scope;
         };
@@ -99,8 +98,8 @@ angular.module('console', ['sql'])
             $scope.renderTable = true;
 
             $scope.resultHeaders = [];
-            for (var col in sqlQuery.cols) {
-              $scope.resultHeaders.push(sqlQuery.cols[col]);
+            for (var i = 0; i < sqlQuery.cols.length; i++) {
+              $scope.resultHeaders.push(sqlQuery.cols[i]);
             }
 
             $scope.rows = sqlQuery.rows;

--- a/app/views/console.html
+++ b/app/views/console.html
@@ -43,7 +43,7 @@
             </div>
 
           </form>
-          
+
         </div>
         <div class="col-lg-12">
           <label>{{ status }}</label>
@@ -57,7 +57,7 @@
           <table class="table table-bordered table-hover tablesorter table-code">
             <thead>
               <tr>
-                <th ng-repeat="header in resultHeaders" class="header">{{ header }}</th>
+                <th ng-repeat="header in resultHeaders track by $index" class="header">{{ header }}</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
when two or more columns with the same name were selected

<img width="1281" alt="screen shot 2015-11-27 at 13 09 23" src="https://cloud.githubusercontent.com/assets/281260/11441012/2b98ae36-9508-11e5-8321-b706dde297fa.png">