### PR TITLE
resolve path to ``/_sql`` endpoint correctly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Resolve path to ``/_sql`` endpoint correctly when Crate is served at a
+   different location than ``/``
+
 2016/05/25 0.18.0
 =================
 

--- a/app/scripts/services/sql.js
+++ b/app/scripts/services/sql.js
@@ -18,7 +18,20 @@ angular.module('sql', [])
       return obj;
     };
   })
-  .factory('SQLQuery', function ($http, $location, $log, $q) {
+  .factory('baseURI', function($location){
+    return function baseURI(path) {
+      var basePath = localStorage.getItem("crate.base_uri");
+      if (!basePath) {
+        var pluginPath = '/_plugin/crate-admin/';
+        basePath = $location.protocol() + "://" +
+                   $location.host() + ":" +
+                   $location.port() +
+                   window.location.pathname.replace(pluginPath, '');
+      }
+      return basePath + path;
+    };
+  })
+  .factory('SQLQuery', function ($http, $log, $q, baseURI) {
     function SQLQuery(stmt, response, error) {
       this.stmt = stmt;
       this.rows = [];
@@ -86,15 +99,11 @@ angular.module('sql', [])
         canceler.reject();
       };
 
-      var baseURI = $location.protocol() + "://" + $location.host() + ":" + $location.port();
-      if (localStorage.getItem("crate.base_uri") != null) {
-        baseURI = localStorage.getItem("crate.base_uri");
-      }
-      $http.post(baseURI+"/_sql", data, {'timeout': canceler.promise}).
-        success(function(data, status, headers, config) {
+      $http.post(baseURI("/_sql"), data, {'timeout': canceler.promise})
+        .success(function(data, status, headers, config) {
           deferred.resolve(new SQLQuery(stmt, data, null));
-        }).
-        error(function(data, status, headers, config) {
+        })
+        .error(function(data, status, headers, config) {
           var error = null;
           if (status >= 400 && data.error) {
             error = new Error(data.error.message);

--- a/app/scripts/services/stats.js
+++ b/app/scripts/services/stats.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
-  .factory('ClusterState', function ($http, $interval, $timeout, $location, $log, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo, ClusterCheck, $q) {
+  .factory('ClusterState', function ($http, $interval, $timeout, $log, baseURI, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo, ClusterCheck, $q) {
     var healthInterval, statusInterval, reachabilityInterval, shardsInterval, checkInterval;
 
     var data = {
@@ -24,10 +24,7 @@ angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
     var historyLength = 180;
 
     var checkReachability = function checkReachability(){
-      var baseURI = $location.protocol() + "://" + $location.host() + ":" + $location.port();
-      var storedURI = localStorage.getItem("crate.base_uri");
-      if (storedURI) baseURI = storedURI;
-      $http.get(baseURI+"/").success(function(response) {
+      $http.get(baseURI("/")).success(function(response) {
         if (typeof response === 'object') {
           var version = response.version;
           data.version = {


### PR DESCRIPTION
in cases when Crate is served at a different location than ``/``, e.g. when proxied to a subdirectory such as ``/crate/`` then also the ``_sql`` endpoint is located at ``/crate/_sql``.
This change removes the hard coded path and resolves the correct location of ``_sql`` based on the relative location to ``/_plugin/crate-admin/``.