### PR TITLE
trim trailing slash from base_uri parameter

### DIFF
--- a/app/scripts/services/sql.js
+++ b/app/scripts/services/sql.js
@@ -28,7 +28,8 @@ angular.module('sql', [])
                    $location.port() +
                    window.location.pathname.replace(pluginPath, '');
       }
-      return basePath + path;
+      // remove trailing slash from base path and append path
+      return basePath.replace(/\/+$/, '') + path;
     };
   })
   .factory('SQLQuery', function ($http, $log, $q, baseURI) {


### PR DESCRIPTION
in order to also allow urls with trailing slash, such as
`http://localhost:4200/` as valid `base_uri` parameter for local
development