### PR TITLE
solved chart onresize error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Fixed the chart error that occured when navigating between the overview and other pages.
+
  - Fixed the logo URL which was not redirecting correctly.
 
  - Added a button to clear the search field in the table list view.

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -177,4 +177,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
     // bind tooltips
     $("[rel=tooltip]").tooltip({ placement: 'top'});
 
+    $scope.$on('$destroy', function(event) {
+      window.onresize = null;
+    });
   });


### PR DESCRIPTION
this error occurs when you change the `route` from/to  the `overview` page, the `window.onresize()` event is triggered and nvd3 cannot calculate the size.

this seems to be fixed in the current nvd3 [version](https://github.com/novus/nvd3/blob/master/src/utils.js#L71). But the version requested by angular-nvd3-directives is much [older](https://github.com/angularjs-nvd3-directives/angularjs-nvd3-directives/blob/master/bower.json#L28) 


@chaudum please review 
