### PR TITLE
add english as fallback

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Fix: added english as a fallback language for translation files.
+
  - Added a button to clear the search field in the table list view.
 
  - Added Spanish translation.

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -115,7 +115,8 @@
           'en_*': 'en',
           'de_*': 'de',
           'es_*': 'es',
-          'zh_*': 'zh'
+          'zh_*': 'zh',
+          '*': 'en'
         })
         // Check local language automatically
         .determinePreferredLanguage()


### PR DESCRIPTION
@chaudum please review 

I think the preferred language that was detected overwrites the fallback language in this line: https://github.com/angular-translate/angular-translate/blob/1f7ec6548e301261810e81ad13e7148400f2be4a/src/service/translate.js#L512 