### PR TITLE
Mk/0.21.2 - preparing release 0.21.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+2016/11/03 0.21.2
+=================
+
  - fixed incorrect sql query for creating the tweets table in the tutorial.
 
 2016/11/02 0.21.1

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "crate-admin",
   "description": "Crate Admin UI",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "author": "Crate Team",
   "homepage": "https://github.com/crate/crate-admin/",
   "license": "Apache License, Version 2.0, http://www.apache.org/licenses/LICENSE-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crate-admin",
   "description": "Crate Admin UI",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "author": "Crate Team",
   "homepage": "https://github.com/crate/crate-admin/",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Tests

### Toolbar

 - [x] Cluster name must be `ADMIN-UI-TEST`
 - [x] Version must correspond to branch version from which Crate was started
<img width="838" alt="screen shot 2016-11-03 at 16 33 28" src="https://cloud.githubusercontent.com/assets/13311684/19973048/584e897a-a1e4-11e6-82c2-70cc17fc6c78.png">

### Overview

 - [x]Toggle Load 1, Load 5, Load 15 in Cluster Load graph
 - [x] Resizing the window must not throw any d3.js errors
http://g.recordit.co/zMwW7GDZjd.gif

### Get Started

 - [x] Import tweets for testing and and stop it again after ~ 10000 imported tweets
<img width="1338" alt="screen shot 2016-11-03 at 16 35 08" src="https://cloud.githubusercontent.com/assets/13311684/19973164/ba3b7fe4-a1e4-11e6-8c7a-0b6317d388de.png">
<img width="1315" alt="screen shot 2016-11-03 at 16 35 14" src="https://cloud.githubusercontent.com/assets/13311684/19973163/ba3912c2-a1e4-11e6-94ea-da31d4d9b6e6.png">

### Console

 - [x] Type `SELECT * FROM tweets;` in the console and hit the execute button.
  `LIMIT 100` must be applied automatically.
<img width="1311" alt="screen shot 2016-11-03 at 16 35 30" src="https://cloud.githubusercontent.com/assets/13311684/19973205/d95173f2-a1e4-11e6-887f-abfb21dd88dc.png">

 - [x] Type `SELECT * FROM sys.summits;` in the console and hit SHIFT+ENTER
  `LIMIT 100` must be applied automatically.
<img width="1316" alt="screen shot 2016-11-03 at 16 36 02" src="https://cloud.githubusercontent.com/assets/13311684/19973221/e917a658-a1e4-11e6-8b22-71b388e83bb7.png">


 - [x] Hit ARROW-UP key in console input field. `SELECT * FROM sys.summits;` must be
  loaded into console. Another ARROW-UP reveals `SELECT * FROM tweets;`
 - [x]Test ARROW-DOWN functionality to test browsing the console history.
http://g.recordit.co/of90R52Sxt.gif

### Tables

- [x] `tweets` table must appear in `Docs Tables` section.

### Cluster

- [x] The master node must be indicated with a blue square.
<img width="294" alt="screen shot 2016-11-03 at 16 47 58" src="https://cloud.githubusercontent.com/assets/13311684/19973389/5d87d454-a1e5-11e6-96e7-fdc5597e3097.png">
