### PR TITLE
Fixed linux viewport issue

### DIFF
--- a/app/styles/common.less
+++ b/app/styles/common.less
@@ -168,7 +168,7 @@ label:hover:before {
   position: absolute;
   top: @status-bar-height;
   left: @side-nav-width;
-  width:  calc(~"100vw -" @side-nav-width + 15px);
+  width:  calc(~"100% -" @side-nav-width);
   height: calc(~"100vh -" @status-bar-height);
 }
 
@@ -338,7 +338,7 @@ label:hover:before {
 @media only screen and (max-width:  @max-width-s){
   #page-wrapper {
     left: @side-nav-width-xs;
-    width:  calc(~"100vw -" @side-nav-width-xs + 15px);
+    width:  calc(~"100% -" @side-nav-width-xs);
   	height: calc(~"100vh -" @status-bar-height);
   }
 }

--- a/app/styles/statusbar.less
+++ b/app/styles/statusbar.less
@@ -11,7 +11,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  width: 100vw;
+  width: 100%;
 
   color: @status-bar-color;
   font-size: @status-bar-font-size;


### PR DESCRIPTION
This fixes an issue that was occurring in Chromium and Firefox on Xubuntu, where the page was larger than the viewport horizontally if a scrollbar was present. It seems like the scrollbar was being considered part of the viewport, so that `100vw` was actually *bigger* than the viewport. Changed to use `100%` instead, which fixes this.