### PR TITLE
updated grunt-contrib-connect dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,11 +1,7 @@
 'use strict';
 
-var mountFolder = function(connect, dir) {
-  var path = require('path');
-  return connect.static(path.resolve(dir));
-};
-
 module.exports = function(grunt) {
+  var serveStatic = require('serve-static');
   // load all grunt tasks
   var matchDep = require('matchdep');
   matchDep.filterDev('grunt-*').forEach(grunt.loadNpmTasks);
@@ -38,16 +34,15 @@ module.exports = function(grunt) {
     connect: {
       options: {
         port: 9000,
-        hostname: 'localhost',
         path: '/'
       },
       dev: {
         options: {
           base: '<%= crate.app %>',
-          middleware: function(connect) {
+          middleware: function() {
             return [
-              mountFolder(connect, crateConf.tmp),
-              mountFolder(connect, crateConf.app)
+              serveStatic(crateConf.tmp),
+              serveStatic(crateConf.app)
             ];
           }
         }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-concurrent": "~0.3.0",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-connect": "~0.3.0",
+    "grunt-contrib-connect": "^1.0.2",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.6.0",
     "grunt-contrib-htmlmin": "~0.2.0",
@@ -39,7 +39,8 @@
     "karma-jasmine": "^1.0.2",
     "karma-mocha-reporter": "~0.2.5",
     "karma-phantomjs-launcher": "^1.0.0",
-    "matchdep": "~0.1.2"
+    "matchdep": "~0.1.2",
+    "serve-static": "^1.11.1"
   },
   "peerDependencies": {
     "grunt-cli": "~0.1.13"


### PR DESCRIPTION
to be able to bind dev server to 0.0.0.0
so the admin ui can be opened from another device
(e.g. windows virtual box)

make sure you run `bin/npm update`!