### PR TITLE
fix tooltip position

### DIFF
--- a/app/scripts/controllers/common.js
+++ b/app/scripts/controllers/common.js
@@ -91,10 +91,6 @@ var commons = angular.module('common', ['stats', 'udc'])
     $scope.navBarElements = NavigationService.navBarElements;
     $scope.showSideNav = false;
 
-    $(".cr-side-nav-item").tooltip({
-      placement: 'right'
-    });
-
     $rootScope.$on("showSideNav", function() {
       $scope.showSideNav = true;
       });
@@ -254,6 +250,19 @@ var commons = angular.module('common', ['stats', 'udc'])
       $scope.selectedLanguage = langKey;
       $scope.toggleDropDown();
     };
+  })
+  .directive('crTooltip', function() {
+    return {
+      restrict: 'A',
+      scope: {
+        crTooltipPosition : '='
+      },
+      link: function(scope, element, attrs) {
+        $(element[0]).tooltip({
+          placement: attrs.crTooltipPosition
+        });
+      }
+    }
   });
 
 

--- a/app/styles/nav.less
+++ b/app/styles/nav.less
@@ -11,6 +11,7 @@
   background-color: @side-nav-background-color;
   display: block;
   height: 100%;
+  z-index: @cr-layout-z-index;
 }
 
 .cr-side-nav__item {

--- a/app/views/nav.html
+++ b/app/views/nav.html
@@ -7,7 +7,8 @@
                 ng-class="{ 'cr-side-nav__item--active': isActive(navBarElement.urlPattern) }"
                 ng-repeat="navBarElement in navBarElements" 
                 ng-click="goToPath(navBarElement.urlPattern)"
-                data-original-title="{{ navBarElement.text }}" rel="tooltip">
+                data-original-title="{{ navBarElement.text }}"
+                cr-tooltip cr-tooltip-position="right">
             <img ng-src="{{ navBarElement.iconSrc }}">
           </div>
       </div>


### PR DESCRIPTION
navigation tooltip position was previously overwritten by other jquery tooltip placements

` $("[rel=tooltip]").tooltip({
      placement: 'bottom'
    });`

<img width="279" alt="screen shot 2016-11-15 at 11 12 09" src="https://cloud.githubusercontent.com/assets/13311684/20301642/6d02d6d4-ab24-11e6-8acd-dfac09015ef0.png">
