### PR TITLE
do not try to append load if load info from node is missing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Fix: do not try to show load history when load information from node is
+   missing
+
  - Local development: do not store ``base_uri`` permanently in localStorage
    but keep it in URL
 

--- a/app/scripts/services/stats.js
+++ b/app/scripts/services/stats.js
@@ -104,9 +104,11 @@ angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
       var load = [0.0, 0.0, 0.0];
       for (var i = 0; i < numNodes; i++) {
         var nodeLoad = nodeInfo[i].load;
-        load[0] += nodeLoad['1'] / numNodes;
-        load[1] += nodeLoad['5'] / numNodes;
-        load[2] += nodeLoad['15'] / numNodes;
+        if (nodeLoad) {
+          load[0] += nodeLoad['1'] / numNodes;
+          load[1] += nodeLoad['5'] / numNodes;
+          load[2] += nodeLoad['15'] / numNodes;
+        }
       }
       addToLoadHistory(load);
       return load;


### PR DESCRIPTION
Caused following JS error:

```
16:38:09.323 Error: nodeLoad is null
prepareLoadInfo@http://localhost:9000/scripts/services/stats.js:107:9
refreshState/<@http://localhost:9000/scripts/services/stats.js:173:23
processQueue@http://localhost:9000/bower_components/angular/angular.js:13318:27
scheduleProcessQueue/<@http://localhost:9000/bower_components/angular/angular.js:13334:27
$RootScopeProvider/this.$get</Scope.prototype.$eval@http://localhost:9000/bower_components/angular/angular.js:14570:16
$RootScopeProvider/this.$get</Scope.prototype.$digest@http://localhost:9000/bower_components/angular/angular.js:14386:15
$RootScopeProvider/this.$get</Scope.prototype.$apply@http://localhost:9000/bower_components/angular/angular.js:14675:13
done@http://localhost:9000/bower_components/angular/angular.js:9725:36
completeRequest@http://localhost:9000/bower_components/angular/angular.js:9915:7
requestLoaded@http://localhost:9000/bower_components/angular/angular.js:9856:9
  angular.js:11706:18
```