### PR TITLE
fix css loading from the right location in grunt server task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,7 +117,7 @@ module.exports = function(grunt) {
           expand: true,
           cwd: '<%= crate.app %>/styles',
           src: 'main.less',
-          dest: '<%= crate.tmp %>/styles/',
+          dest: '<%= crate.tmp %>/static/styles/',
           ext: '.css'
         }]
       }


### PR DESCRIPTION
in `grunt server` task, css was bundled in /styles/main.css. It should be /static/styles/main.css