### PR TITLE
Console now resizes to show all of the query

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - The console now expands vertically to show the whole query if its size
+   is larger than the standard size of the console.
+
  - Fix console results issue that caused the results table not to be displayed
    after horizontal scrolling.
 

--- a/app/styles/console.less
+++ b/app/styles/console.less
@@ -187,7 +187,8 @@ tr > .cr-table-cell {
 .CodeMirror {
   font-family: @font-family-monospace;
   font-size: 16px;
-  height: 120px;
+  min-height: 120px;
+  height: auto;
 }
 
 .cm-keyword {


### PR DESCRIPTION
![contracts](https://cloud.githubusercontent.com/assets/12958979/22594645/40a57efe-ea24-11e6-8080-9e29abf36354.gif)
