### PR TITLE
fixed notification date formatting in safari

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes for Crate Admin Interface
 
 Unreleased
 ==========
+  
+ - Fixed an issue that caused the notification date to be `null` in safari.
 
  - Added buttons to collapse and expand all schemas in the tables view.
 

--- a/app/index.html
+++ b/app/index.html
@@ -65,6 +65,7 @@
     <!-- build:js({.tmp,app}) static/scripts/scripts.js -->
     <script type="application/javascript" src="scripts/app.js"></script>
 
+    <script type="application/javascript" src="scripts/services/utils.js"></script>
     <script type="application/javascript" src="scripts/services/sql.js"></script>
     <script type="application/javascript" src="scripts/services/health.js"></script>
     <script type="application/javascript" src="scripts/services/stats.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -4,6 +4,7 @@ var MODULES = [
   'ngRoute',
   'ngCookies',
   'truncate',
+  'utils',
   'sql',
   'stats',
   'common',

--- a/app/scripts/services/utils.js
+++ b/app/scripts/services/utils.js
@@ -1,0 +1,9 @@
+'use strict';
+
+angular.module('utils', [])
+	.service('parseIsoDatetime', function() {
+		return function(dtstr) {
+			var dt = dtstr.split(/[: T+-]/).map(parseFloat);
+			return new Date(dt[0], dt[1] - 1, dt[2], dt[3] || 0, dt[4] || 0, dt[5] || 0, 0);
+		};
+	});

--- a/app/tests/services/parseIsoDatetime.test.js
+++ b/app/tests/services/parseIsoDatetime.test.js
@@ -1,0 +1,23 @@
+describe('common', function() {
+  'use strict';
+
+  var parseIsoDatetime;
+
+
+  beforeEach(module('common'));
+  beforeEach(module('crate'));
+  beforeEach(module('sql'));
+
+  beforeEach(function() {
+    angular.mock.inject(function($injector) {
+      parseIsoDatetime = $injector.get('parseIsoDatetime');
+    });
+  });
+
+  describe('parseIsoDatetime', function() {
+    it('parseIsoDatetime should parse isodate', inject(function(parseIsoDatetime) {
+      var date = '2015-02-26T16:27:15+0000' ;
+      expect(parseIsoDatetime(date).toDateString()).toEqual('Thu Feb 26 2015');
+    }));
+  });
+});

--- a/app/views/statusbar.html
+++ b/app/views/statusbar.html
@@ -85,13 +85,13 @@
               <div class="notification__item">
                 <div class="notification__status"></div>
                 <div class="notification__content">
-                  <b>{{item.timestamp | date}}</b>
+                  <b>{{item.date | date}}</b>
                   <div ng-bind-html="item.title"></div>
                 </div>
               </div>
             </div>
 
-            <div class="no-notification" ng-show="noNotifications">
+            <div class="no-notification" ng-if="noNotifications">
               <div class="notification__item">
                 <div class="notification__status"></div>
                 <div class="notification__content">


### PR DESCRIPTION
```javascript
              item.timestamp = new Date(item.date);
              console.log(item.date);
              console.log($filter('date')(item.date));
              console.log(item.timestamp);
              console.log($filter('date')(item.timestamp));
```

in Safari this returns :

```

[Log] 2016-12-02T14:08:24+0000 (feed.js, line 97)
[Log] Dec 2, 2016 (feed.js, line 98)
[Log] Invalid Date (feed.js, line 99)
[Log] Invalid Date (feed.js, line 100)

```
apparently item.date which has the format ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)) `2015-02-26T16:27:15+0000` is invalid in Safari which uses ([rfc3339](https://tools.ietf.org/html/rfc3339#section-5.8))

from Safari's console:

``` javascript
> new Date('2015-02-26T16:27:15+0000')
< Invalid Date
> new Date('2015-02-26T16:27:15+00:00')
< Thu Feb 26 2015 17:27:15 GMT+0100 (CET)
```
