### PR TITLE
fixed issue that caused codemirror text to appear on top of settings tab

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Fixed issue that cause the console text to appear on top of the settings tab.
+
  - Fixed load reading display when the readings were invalid (for example,
    on Windows).
 

--- a/app/styles/console.less
+++ b/app/styles/console.less
@@ -287,3 +287,29 @@ tr > .cr-table-cell {
   color: @red;
   cursor: pointer;
 }
+
+// fix up for CodeMiror
+.CodeMirror-code {
+  z-index: 0 !important;
+}
+
+.CodeMirror pre { 
+  z-index: 0 !important;
+}
+
+.CodeMirror pre  span { 
+  z-index: 0 !important;
+}
+
+.CodeMirror-selected {
+  z-index: 0 !important;
+}
+
+.CodeMirror-lines > div > div {
+  z-index: 0 !important;
+}
+
+.cm-s-monokai div.CodeMirror-selected {
+  background-color:rgba(255, 255, 255, 0.1) !important;
+}
+


### PR DESCRIPTION
looks like a known issue of Codemirror https://github.com/codemirror/CodeMirror/issues/3770#issuecomment-172492500

![pasted image at 2017_03_20 17_15](https://cloud.githubusercontent.com/assets/13311684/24145187/59794f0c-0e30-11e7-8fb1-e025844d6017.png)
<img width="1402" alt="screen shot 2017-03-21 at 12 04 52" src="https://cloud.githubusercontent.com/assets/13311684/24145206/69af4520-0e30-11e7-80aa-1f8888c0c4ed.png">
<img width="1399" alt="screen shot 2017-03-21 at 12 05 01" src="https://cloud.githubusercontent.com/assets/13311684/24145207/69af5682-0e30-11e7-8172-bd94fd0d8abf.png">

