### PR TITLE
Updated the stat collection warning for monitoring.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,9 @@ Changes
 Fixes
 -----
 
+ - Cluster warning within the monitoring plugin, regarding
+   stat collection being disabled, has been improved.
+
 2017/04/24 1.3.1
 ================
 

--- a/app/plugins/monitoring/monitoring.html
+++ b/app/plugins/monitoring/monitoring.html
@@ -3,8 +3,11 @@
   <div class="cr-page-header">
     <h1>{{ 'NAVIGATION.MONITORING' | translate }}</h1>
   </div>
-  
-  <p ng-if="stats_enabled === 0"> Cluster stats are disabled. To enable stats, please run <span class="code">`SET GLOBAL stats.enabled TO TRUE`</span>. </p>
+
+  <div ng-if="stats_enabled === 0">
+    <p>Cluster stat collection is <strong>disabled</strong>. To enable stat collection, please run <code>SET GLOBAL stats.enabled TO TRUE</code>, or by adding <code>stats.enabled: true</code> to config/crate.yml.
+    For more information on enabling stat collection, please see the <a href="https://crate.io/docs/reference/configuration.html#collecting-stats">configuration documentation</a>.</p>
+  </div>
 
   <div class="cr-panel-block--checks">
     <div class="cr-panel-block__item--load">


### PR DESCRIPTION
Just waiting on @jodok as to whether this approach is what we want. I thought adding this here, and then information on the performance penalty of collecting stats in the config documentation, would be the right approach - as all users, not just enterprise ones, can enable stat collection and will want to know about its effect on performance.