### PR TITLE
fix toggle buttons display on zoom

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,9 @@ Changes
 
 Fixes
 -----
- 
+
+ - Fix toggle buttons UI, which was broken while zooming.
+
  - Change color of keywords in the console to be more readable.
 
  - Display long table names correctly.

--- a/app/styles/overview.less
+++ b/app/styles/overview.less
@@ -158,24 +158,26 @@
 }
 
 .cr-radio-button__load {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  border: 2px solid @radiobutton-border;
-  display: inline-block;
-  vertical-align: top;
+  width: 14px !important;
+  height: 14px !important;
+  border-radius: 7px !important;
+  border: 2px solid @radiobutton-border !important;
+  display: block;
   position: relative;
   margin-right: 9px;
+  overflow: hidden; 
+  z-index: 1;
 }
 
 .cr-radio-button__load__toggle {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  display: block;
+  width: 30px !important;
+  height: 30px !important;
+  border-radius: 15px !important;
+  margin: 0;
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: -15px;
+  left: -15px;
+
 }
 
 .cr-radio-button__load__toggle--inactive {


### PR DESCRIPTION
adjusted toggle buttons so that they are not broken when the user is using zoom (3 values around 100%)
before:
<img width="747" alt="bildschirmfoto_2017-06-13_um_11 56 15" src="https://user-images.githubusercontent.com/13311684/27273239-7281acc6-54ce-11e7-827c-3de0988cb6b8.png">

after:
http://g.recordit.co/W9Gp70WuZz.gif

