### PR TITLE
fix timestamp formatting in console to use the same default formatting as date_format()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Changes
 Fixes
 -----
 
+ - Fix timestamp formatting in the console results.
+
 2017/07/10 1.4.0
 ================
 

--- a/app/scripts/filter/text.js
+++ b/app/scripts/filter/text.js
@@ -118,7 +118,7 @@ angular.module('common')
   })
   .filter('formatTimestamp', function() {
     return function(timestamp) {
-      return new Date(timestamp).toUTCString();
+      return new Date(timestamp).toISOString();
     };
   })
   .filter('urlEncodedJson', function() {

--- a/app/tests/filter/text.test.js
+++ b/app/tests/filter/text.test.js
@@ -305,8 +305,8 @@ describe('formatTimestamp', function() {
 	it('should return UTC time', function() {
 		var formatTimestamp;
 		formatTimestamp = $filter('formatTimestamp');
-		var milliseconds = Date.now();
-		expect(formatTimestamp(milliseconds)).toBe(new Date(milliseconds).toUTCString());
+		var milliseconds = new Date(0);
+		expect(formatTimestamp(milliseconds.getTime())).toBe("1970-01-01T00:00:00.000Z");
 	});
 });
 


### PR DESCRIPTION
<img width="1281" alt="screen shot 2017-07-10 at 13 54 44" src="https://user-images.githubusercontent.com/13311684/28017122-eb9497e0-6577-11e7-9041-0f331e87cdd1.png">
