### PR TITLE
Changed documentation link to x.y link instead of x.y.z

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,9 @@ Breaking Changes
 Changes
 -------
 
+ - The documentation link now points to the documentation for the major.minor
+   (e.g. 2.1) version of CrateDB, instead of major.minor.hotfix (e.g. 2.1.1).
+
 Fixes
 -----
 

--- a/app/scripts/controllers/common.js
+++ b/app/scripts/controllers/common.js
@@ -48,8 +48,12 @@ var commons = angular.module('common', ['stats', 'udc'])
     }, {});
 
     var DOCS_BASE_URL = 'https://crate.io/docs';
+    var getMajorMinorVersion = function getMajorMinorVersion(version) {
+      var SHORT_VERSION_RE = new RegExp(/(\d+\.\d+)\.\d+.*/);
+      return version ? version.number.match(SHORT_VERSION_RE)[1] : null;
+    };
     var getDocsUrl = function getDocsUrl(version) {
-      return $sce.trustAsResourceUrl(DOCS_BASE_URL + (version ? '/en/' + version.number : '/stable') + '/');
+      return $sce.trustAsResourceUrl(DOCS_BASE_URL + (version ? '/en/' + version : '/stable') + '/');
     };
     $scope.cluster_color_label = '';
     $scope.config_label = '';
@@ -123,7 +127,8 @@ var commons = angular.module('common', ['stats', 'udc'])
       $scope.load15 = data.load[2] == '-.-' ? data.load[2] : data.load[2].toFixed(2);
       $scope.load15 = $scope.load15 < 0 ? 'N/A' : $scope.load15;
       $scope.version = data.version;
-      $scope.docs_url = getDocsUrl(data.version);
+      $scope.major_minor_version = getMajorMinorVersion(data.version);
+      $scope.docs_url = getDocsUrl($scope.major_minor_version);
       $scope.cluster_color_label = data.online ? colorMap[data.status] : '';
     }, true);
 

--- a/app/views/statusbar.html
+++ b/app/views/statusbar.html
@@ -65,7 +65,7 @@
           </div>
 
           <div class="cr-settings__item">
-            <a class="cr-settings__item__label" ng-href="{{ docs_url }}" target="_docs"> {{ 'STATUSBAR.CRATE_MANUAL' | translate }} ({{ version.number }})</a>
+            <a class="cr-settings__item__label" ng-href="{{ docs_url }}" target="_docs"> {{ 'STATUSBAR.CRATE_MANUAL' | translate }} {{major_minor_version && '(' + major_minor_version + ')' || '' }}</a>
           </div>
 
 


### PR DESCRIPTION
This is due to our decision to shift away from building seperate documentation for each hotfix release, and to instead only build for feature releases.