### PR TITLE
fixed twitter tutorial empty account_user column

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Changes
 Fixes
 -----
 
+ - Fixed empty ``account_user``-column in twitter tutorial plugin.
+
 2017/08/23 1.5.1
 ================
 

--- a/app/plugins/tutorial/tutorial.js
+++ b/app/plugins/tutorial/tutorial.js
@@ -45,7 +45,7 @@ angular.module('tutorial', ['sql', 'translation'])
           tweet.retweeted,
           tweet.source,
           tweet.text,
-          tweet.account_user], 
+          tweet.user], 
           false,
           false, 
           false);


### PR DESCRIPTION
wrong property was accessed. column is now being filled.