### PR TITLE
fixed an issue that cause the overview chart to be slow to display

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Changes
 Fixes
 -----
 
+ - Fixed an issue that delayed the overview chart's initial display.  
+
  - Fixed issue that caused the redirect to ``/401`` in case of 
    unauthorized access to fail. 
 

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -55,6 +55,11 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
           },
           axisLabelDistance: -10,
           showMaxMin: false
+        },
+        dispatch: {
+          renderEnd: function () {
+            $scope.api.update();
+          }
         }
       }
     };
@@ -155,8 +160,10 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
           }
         });
     };
-    $scope.callback = function() {
-      $scope.api.clearElement();
+
+    $scope.config = {
+      visible: true, 
+      debounce: 5 
     };
 
     $scope.dismissCheck = function(check) {

--- a/app/views/console.html
+++ b/app/views/console.html
@@ -44,7 +44,6 @@
               <div class="cr-console-header__options__item--hint">{{:: 'CONSOLE.HINT' | translate }}</div>
               <div id="execute-btn" class="cr-console-header__options__item--btn cr-button cr-button--console" ng-click="execute()">
                 <div ng-class="loading ? 'faded-text' : ''" translate>{{:: 'CONSOLE.EXCUTE_QUERY' }}</div>
-                <div ng-if="loading" class="cr-loading-indicator"><i class="fa fa-spinner pulse fa-2x fa-fw cr-loading-indicator-icon"></i></div>
               </div>
               <div id="share-btn" class="cr-console-header__options__item--btn cr-button cr-button--console" ng-click="share()" data-original-title="Copy query link to clipboard" cr-tooltip cr-tooltip-position="bottom">
                 <img src="static/assets/icon-share.svg"/>
@@ -66,6 +65,11 @@
         <pre id="error-trace"><code>{{ error.error_trace }}</code></pre>
       </div>
     </div>
+    <div class="progress"  ng-if="loading">
+        <div class="indeterminate"></div>
+    </div>
+
+
 
     <div ng-if="renderTable" class="query-result-container" ng-class="{colourised: formatResults}">
 

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -69,7 +69,7 @@
           Load 15</a>
       </div>
       <div class="cr-panel-block__chart">
-        <nvd3 id="cluster-load" on-ready="callback" api="api" options="options" data="chart.data"></nvd3>
+        <nvd3 id="cluster-load" api="api" options="options" data="chart.data" config="config"></nvd3>
       </div>
     </div>
 


### PR DESCRIPTION
I think the issue is related to the $digest cycle, so it seems that the chart waits for the next cycle to be displayed..

So I'm not sure if this is the best solution, but it does make the chart display faster