### PR TITLE
create ClusterEventsHandler service

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -71,6 +71,7 @@
     <script type="application/javascript" src="scripts/services/udc.js"></script>
     <script type="application/javascript" src="scripts/services/translation.js"></script>
     <script type="application/javascript" src="scripts/services/datatypechecks.js"></script>
+    <script type="application/javascript" src="scripts/services/clusterEventsHandler.js"></script>
 
     <script type="application/javascript" src="scripts/controllers/common.js"></script>
     <script type="application/javascript" src="scripts/controllers/feed.js"></script>

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('overview', ['stats', 'checks', 'ngSanitize'])
+angular.module('overview', ['stats', 'checks', 'ngSanitize', 'events'])
   .factory('NullArray', function() {
     return {
       create: function(len) {
@@ -13,7 +13,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
     };
   })
   .controller('OverviewController', function($scope, $location, $log, $timeout, $interval, ClusterState, NullArray, ChecksService, SQLQuery, 
-  SeverityClass) {
+  SeverityClass, ClusterEventsHandler) {
     var colorMap = {
       'good': 'cr-panel--success',
       'warning': 'cr-panel--warning',
@@ -84,7 +84,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
       }
     };
 
-    $scope.$on('checksService.refreshed', function() {
+    ClusterEventsHandler.register('CHECKS_REFRESHED', 'OverviewController', function() {
       if (ChecksService.success === true) {
         $scope.checks = ChecksService.checks;
       } else {
@@ -219,7 +219,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
       }
     };
 
-    $scope.$on('clusterState.refreshed', updateClusterData);
+    ClusterEventsHandler.register('STATE_REFRESHED', 'OverviewController', updateClusterData);
     updateClusterData();
 
     // bind tooltips
@@ -233,5 +233,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize'])
     });
     $scope.$on('$destroy', function() {
       $scope.api.clearElement();
+      ClusterEventsHandler.remove('CHECKS_REFRESHED', 'OverviewController');
+      ClusterEventsHandler.remove('STATE_REFRESHED', 'OverviewController');
     });
   });

--- a/app/scripts/services/checks.js
+++ b/app/scripts/services/checks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-angular.module('checks', ['sql'])
+angular.module('checks', ['sql', 'events'])
   .factory('ClusterCheck', function(SQLQuery, queryResultToObjects, $q) {
     var self = {
       deferred: $q.defer()
@@ -77,7 +77,7 @@ angular.module('checks', ['sql'])
 
     return self;
   })
-  .factory('ChecksService', function($timeout, $q, NodeCheck, ClusterCheck, $rootScope) {
+  .factory('ChecksService', function($timeout, $q, NodeCheck, ClusterCheck, $rootScope, ClusterEventsHandler) {
     var data = {
       checks: {},
       success: false,
@@ -94,14 +94,14 @@ angular.module('checks', ['sql'])
           if (force !== true) {
             $timeout(data.fetch, 60000);
           }
-          $rootScope.$broadcast('checksService.refreshed');
+          ClusterEventsHandler.trigger('CHECKS_REFRESHED');
         }).catch(function() {
           data.success = false;
           retryCount++;
           if (force !== true) {
             $timeout(data.fetch, 500 * retryCount);
           }
-          $rootScope.$broadcast('checksService.refreshed');
+          ClusterEventsHandler.trigger('CHECKS_REFRESHED');
         });
     };
     // Initial fetch

--- a/app/scripts/services/clusterEventsHandler.js
+++ b/app/scripts/services/clusterEventsHandler.js
@@ -1,0 +1,32 @@
+'use strict';
+
+angular.module('events', [])
+  .service('ClusterEventsHandler', function () {
+    var listeners = {};
+    var service = {};
+
+    service.register = function register(event_name, controller_name, callback) {
+      if (!listeners[event_name]) {
+        listeners[event_name] = {};
+      }
+      listeners[event_name][controller_name] = callback;
+    };
+
+    service.trigger = function trigger(event_name) {
+      for (var controller in listeners[event_name]) {
+        //get callback
+        var callback = listeners[event_name][controller];
+        //execute callback
+        callback();
+      }
+    };
+
+    service.remove = function register(event_name, controller_name) {
+      delete listeners[event_name][controller_name];
+      if (listeners[event_name] === {}) {
+        delete listeners[event_name];
+      }
+    };
+
+    return service;
+  });

--- a/app/scripts/services/stats.js
+++ b/app/scripts/services/stats.js
@@ -1,18 +1,13 @@
 'use strict';
 
-angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
-  .factory('ClusterState', function($http, $interval, $timeout, $log, $q, $rootScope,
-  baseURI, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo) {
-    var healthInterval,
-      statusInterval,
-      reachabilityInterval,
-      shardsInterval,
-      checkInterval;
+angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo', 'events'])
+  .factory('ClusterState', function ($http, $interval, $timeout, $log, $q, $rootScope,
+    baseURI, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo, ClusterEventsHandler) {
+    var reachabilityInterval,
+      ClusterStateInterval;
 
     // definition of function variables
-    var refreshShardInfo,
-      refreshState,
-      refreshHealth,
+    var refreshClusterState,
       checkReachability,
       setReachability;
 
@@ -37,10 +32,7 @@ angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
       if (data.online && !online) {
         data.online = false;
         $log.warn('Cluster is offline.');
-        $interval.cancel(healthInterval);
-        $interval.cancel(statusInterval);
-        $interval.cancel(shardsInterval);
-        $interval.cancel(checkInterval);
+        $interval.cancel(ClusterStateInterval);
         data.status = '--';
         data.tables = [];
         data.cluster = [];
@@ -51,34 +43,33 @@ angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
       } else if (!data.online && online) {
         data.online = true;
         $log.info('Cluster is online.');
-        healthInterval = $interval(refreshHealth, refreshInterval);
-        refreshHealth();
-        statusInterval = $interval(refreshState, refreshInterval);
-        refreshState();
-        shardsInterval = $interval(refreshShardInfo, refreshInterval);
-        refreshShardInfo();
+        ClusterStateInterval = $interval(refreshClusterState, refreshInterval);
+        refreshClusterState();
       }
     };
 
     checkReachability = function() {
       $http.get(baseURI.getURI('/'), {
-          headers: {'Accept': 'application/json'}
-        }).success(function(response) {
-          if (typeof response === 'object') {
-            var version = response.version;
-            data.version = {
-              number: version.number,
-              hash: version.build_hash,
-              snapshot: version.build_snapshot
-            };
-            setReachability(true);
-          } else {
-            data.version = null;
-            setReachability(false);
-          }
-        }).error(function() {
+        headers: {
+          'Accept': 'application/json'
+        }
+      }).success(function (response) {
+        if (typeof response === 'object') {
+          var version = response.version;
+          data.version = {
+            number: version.number,
+            hash: version.build_hash,
+            snapshot: version.build_snapshot
+          };
+          setReachability(true);
+        } else {
+          data.version = null;
           setReachability(false);
-        });
+        }
+
+      }).error(function () {
+        setReachability(false);
+      });
     };
 
     var addToLoadHistory = function(load) {
@@ -147,127 +138,75 @@ angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo'])
       return nodeInfo;
     };
 
-    refreshHealth = function() {
-      // We want to get the tables as soon as they become available so we use the promise object.
-      TableList.execute()
-        .then(null, null, function(res){
-          if (res.success || !data.online) {
-            var h = res.data.tables.reduce(function(memo, obj){
-              var health = Health.fromString(obj.health);
-              return Math.max(health.level, memo);
-            }, 0);
-            data.status = new Health(h).name;
-            data.tables = res.data.tables;
-          } else {
-            data.status = '--';
-            data.tables = [];
-          }
-          $rootScope.$broadcast('clusterState.refreshed');
-        });
-    };
+  refreshClusterState = function () {
+    if (!data.online) {
+      return;
+    }
+    $q.all([ShardInfo.executeTableStmt(),
+              ShardInfo.executeShardStmt(),
+              ShardInfo.executePartStmt(),
+              ShardInfo.executeRecoveryStmt(),
+              NodeInfo.executeClusterQuery(),
+              NodeInfo.executeNodeQuery()])
+      .then(function (values) {
 
-    refreshState = function() {
-      NodeInfo.executeNodeQuery()
-        .then(function(response){
-          if (!data.online) {
-            return;
-          }
-          data.load = prepareLoadInfo(response);
-          data.cluster = prepareIoStats(response);
-          NodeInfo.executeClusterQuery()
-            .then(function(response){
-              if (!data.online) {
-                return;
-              }
-              data.name = response[0].name;
-              data.master_node = response[0].master_node;
-              // resolve global NodeInfo deferred object
-              var result = {
-                name: data.name,
-                master_node: data.master_node,
-                nodes: data.cluster.length
-              };
-              NodeInfo.deferred.resolve(result);
-              $rootScope.$broadcast('clusterState.refreshed');
-            }, onErrorResponse);
-        }, onErrorResponse);
-    };
+        data.tables = values[0];
+        data.shards = values[1];
+        data.partitions = values[2];
+        data.recovery = values[3];
 
-    refreshShardInfo = function() {
-      if (!data.online) {
-        return;
-      }
+        // resolve global ShardInfo deferred object
+        var result = {
+          tables: data.tables,
+          shards: data.shards,
+          partitions: data.partitions,
+          recovery: data.recovery
+        };
 
-      // table statement
-      ShardInfo.executeTableStmt()
-        .then(function(tables) {
+        ShardInfo.deferred.resolve(result);
 
-          // shard statement
-          ShardInfo.executeShardStmt()
-            .then(function(shards) {
+        var nodeinfo = values[4];
 
-              // partition statement
-              ShardInfo.executePartStmt()
-                .then(function(partitions) {
+        data.name = nodeinfo[0].name;
+        data.master_node = nodeinfo[0].master_node;
 
-                  // recovery statement
-                  ShardInfo.executeRecoveryStmt()
-                    .then(function(recovery) {
-                      data.shards = shards;
-                      data.tables = tables;
-                      data.partitions = partitions;
-                      data.recovery = recovery;
-                      // resolve global ShardInfo deferred object
-                      var result = {
-                        tables: data.tables,
-                        shards: data.shards,
-                        partitions: data.partitions,
-                        recovery: data.recovery
-                      };
-                      ShardInfo.deferred.resolve(result);
-                      $rootScope.$broadcast('clusterState.refreshed');
-                    }).catch(function() {
-                      var result = {
-                        tables: data.tables,
-                        shards: data.shards,
-                        partitions: data.partitions
-                      };
-                      ShardInfo.deferred.reject(result);
-                      $rootScope.$broadcast('clusterState.refreshed');
-                    });
-                }).catch(function() {
-                  var result = {
-                    tables: data.tables,
-                    shards: data.shards
-                  };
-                  ShardInfo.deferred.reject(result);
-                  $rootScope.$broadcast('clusterState.refreshed');
-                });
-            }).catch(function() {
-              var result = {
-                tables: data.tables
-              };
-              ShardInfo.deferred.reject(result);
-              $rootScope.$broadcast('clusterState.refreshed');
-            });
-        }).catch(function () {
-          ShardInfo.deferred.reject({});
-          $rootScope.$broadcast('clusterState.refreshed');
-        });
-    };
+        // resolve global NodeInfo deferred object
+        var nodeinfoResult = {
+          name: data.name,
+          master_node: data.master_node,
+          nodes: data.cluster.length
+        };
 
+        NodeInfo.deferred.resolve(nodeinfoResult);
+
+        var clusterinfo = values[5];
+        data.load = prepareLoadInfo(clusterinfo);
+        data.cluster = prepareIoStats(clusterinfo);
+
+        var tableinfo = TableList.execute(data.tables, data.shards, data.partitions, data.recovery);
+
+        if (tableinfo.success) {
+          var h = tableinfo.data.tables.reduce(function (memo, obj) {
+            var health = Health.fromString(obj.health);
+            return Math.max(health.level, memo);
+          }, 0);
+          data.status = new Health(h).name;
+          data.tables = tableinfo.data.tables;
+        } 
+        ClusterEventsHandler.trigger('STATE_REFRESHED');
+      }).catch(function (query) {
+        onErrorResponse(query);
+        ShardInfo.deferred.reject({});
+        data.status = '--';
+        data.tables = [];
+        ClusterEventsHandler.trigger('STATE_REFRESHED');
+      });
+  };
     checkReachability();
     reachabilityInterval = $interval(checkReachability, refreshInterval);
 
-    refreshHealth();
-    healthInterval = $interval(refreshHealth, refreshInterval);
-
-    refreshShardInfo();
-    shardsInterval = $interval(refreshShardInfo, refreshInterval);
-
-    refreshState();
-    $timeout(refreshState, 500); // we want IOPs quickly!
-    statusInterval = $interval(refreshState, refreshInterval);
+    refreshClusterState();
+    ClusterStateInterval = $interval(refreshClusterState, refreshInterval);
 
     return {
       data: data,

--- a/app/tests/services/stats.tests.js
+++ b/app/tests/services/stats.tests.js
@@ -452,13 +452,8 @@ describe('ClusterState ', function() {
         name: 'admin-ui-test',
         status: 'warning',
         load: [2.38427734375, 2.37646484375, 2.2744140625],
-        loadHistory: [
-          [2.38427734375, 2.38427734375],
-          [2.37646484375, 2.37646484375],
-          [2.2744140625, 2.2744140625]
-        ],
+        loadHistory: [[2.38427734375], [2.37646484375], [2.2744140625]],
         version: null,
-        master_node: 'PSET9VyuRCmb2qH9zXwC7w',
         recovery: [Object({
           Objectcount: 4,
           recovery_percent: null,
@@ -483,7 +478,8 @@ describe('ClusterState ', function() {
           recovery_stage: 'DONE',
           schema_name: 'doc',
           table_name: 'insert_test2'
-        })]
+        })],
+        master_node: 'PSET9VyuRCmb2qH9zXwC7w'
       }));
     }));
   });

--- a/app/tests/services/tableinfo.tableList.test.js
+++ b/app/tests/services/tableinfo.tableList.test.js
@@ -18,33 +18,52 @@ describe('tableinfo TableList', function() {
 
   describe('mockTableList', function() {
     it('should return table list object', inject(function() {
-      var data1 = {
-        partitions: [],
-        recovery: [{
-          count: 4,
-          recovery_percent: null,
-          recovery_stage: null,
-          schema_name: "doc",
-          table_name: "insert_test2"
+
+      var result = mockTableList.execute([{
+          fqn: "doc.insert_test",
+          health: "warning",
+          health_label_class: "label-warning",
+          health_panel_class: "cr-panel--warning",
+          name: "insert_test",
+          partitioned: false,
+          partitioned_by: [],
+          records_total: 1,
+          records_total_with_replicas: 2,
+          records_unavailable: 0,
+          records_underreplicated: 1,
+          recovery_percent: 50,
+          replicas_configured: "1",
+          shards_configured: 4,
+          shards_missing: 0,
+          shards_started: 4,
+          shards_underreplicated: 4,
+          size: 3578,
+          summary: "1 Underreplicated Records / 4 Underreplicated Shards / 4 Shards / 1 Replicas",
+          table_schema: "doc",
+          type_display_name: "TABLE.RECORDS"
         }, {
-          count: 4,
-          recovery_percent: null,
-          recovery_stage: null,
-          schema_name: "doc",
-          table_name: "insert_test"
-        }, {
-          count: 4,
-          recovery_percent: 0,
-          recovery_stage: "DONE",
-          schema_name: "doc",
-          table_name: "insert_test2"
-        }, {
-          count: 4,
-          recovery_percent: 0,
-          recovery_stage: "DONE",
-          table_name: "insert_test"
-        }],
-        shards: [{
+          fqn: "doc.insert_test2",
+          health: "warning",
+          health_label_class: "label-warning",
+          health_panel_class: "cr-panel--warning",
+          name: "insert_test2",
+          partitioned: false,
+          partitioned_by: Array[0],
+          records_total: 0,
+          records_total_with_replicas: 0,
+          records_unavailable: 0,
+          records_underreplicated: 0,
+          recovery_percent: 50,
+          replicas_configured: "1",
+          shards_configured: 4,
+          shards_missing: 0,
+          shards_started: 4,
+          shards_underreplicated: 4,
+          size: 636,
+          summary: "4 Underreplicated Shards / 4 Shards / 1 Replicas",
+          table_schema: "doc",
+          type_display_name: "TABLE.RECORDS"
+        }], [{
           avg_docs: 0.25,
           count: 4,
           fqn: "doc.insert_test",
@@ -96,61 +115,32 @@ describe('tableinfo TableList', function() {
           state: "UNASSIGNED",
           sum_docs: 0,
           table_name: "insert_test"
-        }],
-        tables: [{
-          fqn: "doc.insert_test",
-          health: "warning",
-          health_label_class: "label-warning",
-          health_panel_class: "cr-panel--warning",
-          name: "insert_test",
-          partitioned: false,
-          partitioned_by: [],
-          records_total: 1,
-          records_total_with_replicas: 2,
-          records_unavailable: 0,
-          records_underreplicated: 1,
-          recovery_percent: 50,
-          replicas_configured: "1",
-          shards_configured: 4,
-          shards_missing: 0,
-          shards_started: 4,
-          shards_underreplicated: 4,
-          size: 3578,
-          summary: "1 Underreplicated Records / 4 Underreplicated Shards / 4 Shards / 1 Replicas",
-          table_schema: "doc",
-          type_display_name: "TABLE.RECORDS"
+        }], [], [{
+          count: 4,
+          recovery_percent: null,
+          recovery_stage: null,
+          schema_name: "doc",
+          table_name: "insert_test2"
         }, {
-          fqn: "doc.insert_test2",
-          health: "warning",
-          health_label_class: "label-warning",
-          health_panel_class: "cr-panel--warning",
-          name: "insert_test2",
-          partitioned: false,
-          partitioned_by: Array[0],
-          records_total: 0,
-          records_total_with_replicas: 0,
-          records_unavailable: 0,
-          records_underreplicated: 0,
-          recovery_percent: 50,
-          replicas_configured: "1",
-          shards_configured: 4,
-          shards_missing: 0,
-          shards_started: 4,
-          shards_underreplicated: 4,
-          size: 636,
-          summary: "4 Underreplicated Shards / 4 Shards / 1 Replicas",
-          table_schema: "doc",
-          type_display_name: "TABLE.RECORDS"
-        }]
-      };
+          count: 4,
+          recovery_percent: null,
+          recovery_stage: null,
+          schema_name: "doc",
+          table_name: "insert_test"
+        }, {
+          count: 4,
+          recovery_percent: 0,
+          recovery_stage: "DONE",
+          schema_name: "doc",
+          table_name: "insert_test2"
+        }, {
+          count: 4,
+          recovery_percent: 0,
+          recovery_stage: "DONE",
+          table_name: "insert_test"
+        }]);
 
-      mockShardInfo.deferred.resolve(data1);
-      $rootScope.$apply();
-
-      mockTableList.fetch();
-      $rootScope.$apply();
-
-      expect(mockTableList.data).toEqual({
+      expect(result.data).toEqual({
         tables: [Object({
           fqn: 'doc.insert_test',
           health: 'warning',
@@ -198,18 +188,5 @@ describe('tableinfo TableList', function() {
         })]
       });
     }));
-
-    it('should reject request', inject(function() {
-
-
-      mockShardInfo.deferred.reject();
-      $rootScope.$apply();
-
-      mockTableList.fetch();
-      $rootScope.$apply();
-
-      expect(mockTableList.data).toEqual({ tables: [  ] });
-    }));
-
   });
 });


### PR DESCRIPTION
create ClusterEventsHandler service
use $q.all in stats.js to reduce event triggers
update TableList service to use already available shardInfo data


-----

the table TableList service was querying the 4 shardInfo queries every 5sec, even though the ClusterState service was doing the same.

I also joined all the promises in stats.js under a $q.all, in order to notify the controllers only once, (and not every time one of those promises is successful/or failed)