### PR TITLE
replicated shards in the unassigned row of the Shards view are now grouped by id

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,9 @@ Changes
 Fixes
 -----
 
+ - Replicates shards in the ``Unassigned`` row of the Shards view 
+   are now grouped by id.
+
  - Fixed issue that caused closed partitions to show a ``CRITICAL`` 
    data state.
 

--- a/app/plugins/shards/shards.css
+++ b/app/plugins/shards/shards.css
@@ -65,6 +65,7 @@ th.th--no-borders ,tr > th.cr-table-cell.th--no-borders {
   display: flex;
   justify-content: space-around;
   align-items: center; 
+  position: relative;
 }
 
 .cr-table-cell {
@@ -204,4 +205,17 @@ th.th--no-borders ,tr > th.cr-table-cell.th--no-borders {
   #shards-table--options {
     margin-bottom: 0px !important;
   }
+}
+
+.shard-replicas{  
+  position: absolute;
+  background: #ff7d00;
+  color: rgba(255, 255, 255, 0.70);
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  font-size: 8px;
+  text-align: center;
+  top: -6px;
+  left: 11px;
 }

--- a/app/plugins/shards/shards.html
+++ b/app/plugins/shards/shards.html
@@ -120,6 +120,7 @@
                 <shard-wrapper length="shard_by_table_value.shards.length"  class="shard-item-wrapper"> 
                   <div ng-repeat="(shard_key, shard_value) in shard_by_table_value.shards track by shard_key" class="shard-item" ng-class="shard_value.state_class"  data-key="{{shard_value.key}}" data-table="{{shard_by_table_key}}" data-node="unassigned" data-id="{{shard_value.id}}">
                     <span class="shard-number" ng-show="idOption">{{ shard_value.id }}</span>
+                    <div class="shard-replicas" ng-if="shard_value.replicas">{{ shard_value.replicas + 1 }}</div>
                   </div> 
                 </shard-wrapper>   
               </td>

--- a/app/plugins/shards/shards.js
+++ b/app/plugins/shards/shards.js
@@ -349,13 +349,21 @@ angular.module('shards', ['sql', 'events'])
           // re-init old_id
           old_id = 0;
 
-
-          nodeFormat.shards_by_table[obj.key].shards.push({
-            'state_class': $filter('shardStateClass')(obj.state, obj.primary) + ' ' + [obj.key, obj.id].join('-').replace(/\./g, '-'),
-            'key': [obj.key, obj.id].join('-').replace(/\./g, '-'),
-            'id': obj.id,
-          });
-
+          if (nodeFormat.shards_by_table[obj.key].shards[obj.id]) {
+            // if there is already a shard with the same id, 
+            // we increase the number of replicas.
+            // This will occur in the case of unassigned shards of the same id
+            var replicas = nodeFormat.shards_by_table[obj.key].shards[obj.id].replicas;
+            nodeFormat.shards_by_table[obj.key].shards[obj.id].replicas = replicas == undefined ? 1 : replicas + 1;
+          } else {
+            // if the shard is not already in the list we will add it
+            var shard_key = [obj.key, obj.id].join('-').replace(/\./g, '-');
+            nodeFormat.shards_by_table[obj.key].shards.push({
+              'state_class': $filter('shardStateClass')(obj.state, obj.primary) + ' ' + shard_key,
+              'key': shard_key,
+              'id': obj.id,
+            });
+          }
           nodeFormat.shards_by_table[obj.key].table_name = obj.table_name;
           nodeFormat.shards_by_table[obj.key].schema_name = obj.schema_name;
           nodeFormat.shards_by_table[obj.key].partition_ident = obj.partition_ident;


### PR DESCRIPTION
example 
<img width="1090" alt="screen shot 2017-11-08 at 13 51 05" src="https://user-images.githubusercontent.com/13311684/32550035-e52a76b8-c48b-11e7-8986-68348c5d3288.png">

<img width="1300" alt="screen shot 2017-11-08 at 13 50 06" src="https://user-images.githubusercontent.com/13311684/32550018-d2bd9ece-c48b-11e7-99d3-cbc768997345.png">
