### PR TITLE
updated CPU graph to use value from os['cpu']['used']

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,7 +10,9 @@ Breaking Changes
 
 Changes
 -------
- 
+
+ - Updated CPU usage graph to use the value provided by ``os['cpu']['used']``.
+
 Fixes
 -----
 

--- a/app/scripts/controllers/cluster.js
+++ b/app/scripts/controllers/cluster.js
@@ -256,33 +256,19 @@ angular.module('cluster', ['stats', 'sql', 'common', 'nodeinfo', 'events'])
         var drawGraph = function (node) {
 
           $scope.cpuData = [{
-            'key': 'System',
+            'key': 'Used',
             'values': [{
               'label': 'CPU',
-              'value': node.cpu.system
+              'value': node.cpu.used
           }],
             'color': COLORS.used
         }, {
-            'key': 'User',
+            'key': 'Free',
             'values': [{
               'label': 'CPU',
-              'value': node.cpu.user
-          }],
-            'color': '#5d89fe'
-        }, {
-            'key': 'Idle',
-            'values': [{
-              'label': 'CPU',
-              'value': Math.max(0, 100 - node.cpu.system - node.cpu.user - node.cpu.stolen)
+              'value': 100 - node.cpu.used
           }],
             'color': COLORS.free
-        }, {
-            'key': 'Stolen',
-            'values': [{
-              'label': 'CPU',
-              'value': node.cpu.stolen
-          }],
-            'color': '#f6bb41'
         }];
 
           $scope.heapData = [{


### PR DESCRIPTION
required for CrateDB 2.3
system/user/stolen values have been deprecated and return -1