### PR TITLE
Fixed an issue that caused the table list to display wrong results

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Changes
 Fixes
 -----
 
+ - Fixed an issue that caused the table list to display wrong results.
+
 2018/02/09 1.8.2
 ================
 

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -353,6 +353,7 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
         $scope.collapsed = true;
 
         function updateTableList() {
+            $scope.tables = [];
             var tables = ClusterState.data.tables;
             var hasTables = tables.length > 0;
             $scope.renderSidebar = hasTables;
@@ -378,7 +379,6 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
                 customSchemas.push(name);
               }
 
-              $scope.tables = [];
               $scope.tables.push({
                 'display_name': 'Doc',
                 'tables': tables.filter(function (item) {
@@ -401,9 +401,6 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
                 }),
                 table_schema: 'blob'
               });
-
-            } else {
-              $scope.tables = [];
             }
           }
 

--- a/app/views/tablelist.html
+++ b/app/views/tablelist.html
@@ -22,11 +22,11 @@
         <div class="table__tab__header" id="table-nav-tab-header-{{$index}}" ng-class="isCollapsed($index) ? '' : 'table__tab__tab-header--selected'">
           <div class="side-bar__header table__tab__header" ng-click="toggleElements($index)">
             <i class="fa fa-caret-down" ng-class="{'fa-caret-down': !isCollapsed($index), 'fa-caret-right': isCollapsed($index)}"></i>
-            {{:: type.display_name }} {{ 'TABLE.TITLE' | translate }}</div>
+            {{ type.display_name }} {{ 'TABLE.TITLE' | translate }}</div>
         </div>
 
         <div class="tables-list" id="tables-list--{{$index}}" ng-class="{'collapse': isCollapsed($index), 'in': !isCollapsed($index)}">
-          <div class="side-bar__element tables-list__element" ng-class="{ 'active': isActive(table.table_schema, table.name)}" ng-repeat="table in type.tables | filter:search track by $index">
+          <div class="side-bar__element tables-list__element" ng-class="{ 'active': isActive(table.table_schema, table.name)}" ng-if="renderSidebar" ng-repeat="table in type.tables | filter:search track by $index">
             <a href="#!/tables/{{:: table.table_schema }}/{{:: table.name }}">
               <div class="table-name-row">
                 <div class="table-name">


### PR DESCRIPTION
this issue was introduced with the one-time binding commit. solved by adding `ng-if="renderSidebar"` to force re-rendering the table list