### PR TITLE
fix up LICENCE and NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,3 @@
-Crate Admin Interface
-Copyright 2013-2015 CRATE Technology GmbH ("Crate")
-
-
-Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")
-under one or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information regarding copyright
-ownership.
-
-Crate licenses this software to you under the Apache License, Version 2.0.
-However, if you have executed another commercial license agreement with
-Crate these terms will supersede the license and you may use the software
-solely pursuant to the terms of the relevant commercial agreement.
-
-
-=========================================================================
-
 
                                  Apache License
                            Version 2.0, January 2004
@@ -217,3 +200,181 @@ solely pursuant to the terms of the relevant commercial agreement.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+================================================================================
+
+For the `app/static/fonts/SourceCodePro` directory:
+
+Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/), with
+Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of
+Adobe Systems Incorporated in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+
+================================================================================
+
+For the `bootstrap.py` file:
+
+Buildout <http://www.buildout.org/en/latest/>
+
+Copyright (c) 2006 Zope Foundation and Contributors.
+All Rights Reserved.
+
+This software is subject to the provisions of the Zope Public License,
+Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+FOR A PARTICULAR PURPOSE.
+
+Zope Public License (ZPL) Version 2.0
+-----------------------------------------------
+
+This software is Copyright (c) Zope Corporation (tm) and
+Contributors. All rights reserved.
+
+This license has been certified as open source. It has also
+been designated as GPL compatible by the Free Software
+Foundation (FSF).
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions in source code must retain the above
+   copyright notice, this list of conditions, and the following
+   disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions, and the following
+   disclaimer in the documentation and/or other materials
+   provided with the distribution.
+
+3. The name Zope Corporation (tm) must not be used to
+   endorse or promote products derived from this software
+   without prior written permission from Zope Corporation.
+
+4. The right to distribute this software or to use it for
+   any purpose does not give you the right to use Servicemarks
+   (sm) or Trademarks (tm) of Zope Corporation. Use of them is
+   covered in a separate agreement (see
+   http://www.zope.com/Marks).
+
+5. If any files are modified, you must cause the modified
+   files to carry prominent notices stating that you changed
+   the files and the date of any change.
+
+Disclaimer
+
+  THIS SOFTWARE IS PROVIDED BY ZOPE CORPORATION ``AS IS''
+  AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT
+  NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+  AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN
+  NO EVENT SHALL ZOPE CORPORATION OR ITS CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+  DAMAGE.
+
+
+This software consists of contributions made by Zope
+Corporation and many individuals on behalf of Zope
+Corporation.  Specific attributions are listed in the
+accompanying credits file.

--- a/NOTICE
+++ b/NOTICE
@@ -1,98 +1,11 @@
-Crate Admin Interface
-Copyright 2013-2015 CRATE Technology GmbH
+CrateDB Admin Interface
+Copyright 2013-2018 Crate.IO GmbH ("Crate")
 
-Third party dependencies:
 
-=========================================================================
+Licensed to Crate.IO GmbH (referred to in this notice as "Crate") under one or
+more contributor license agreements.
 
-Font: Blender Pro
-http://binnenland.ch
-Published by Die Gestalten Verlag GmbH & Co. KG, 2008
-Copyright © by Binnenland and re-p.org, 2008.
-Licensed to CRATE Technology GmbH under an "Extended Business End User
-Licence Agreement and Webfont End User Licence Agreement" solely for use
-in the Crate Administration User Interface
-
-=========================================================================
-
-Font: Source Code Pro
-http://www.adobe.com
-Copyright 2010, 2012 Adobe Systems Incorporated
-Font License: SIL OFL, Version 1.1. (http://scripts.sil.org/OFL)
-
-=========================================================================
-
-Buildout
-http://www.buildout.org
-Copyright (c) 2006 Zope Foundation and Contributors.
-License: Zope Public License, Version 2.1 (ZPL)
-
-=========================================================================
-
-RequireJS
-http://requirejs.org
-Copyright (c) 2010-2014, The Dojo Foundation
-License: BSD-3-Clause (http://opensource.org/licenses/BSD-3-Clause)
-
-=========================================================================
-
-jQuery
-http://jquery.com/
-Copyright 2014 jQuery Foundation and other contributors
-License: MIT (http://opensource.org/licenses/MIT)
-
-=========================================================================
-
-Underscore.js
-http://underscorejs.org
-Copyright (c) 2009-2014 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
-License: MIT (http://opensource.org/licenses/MIT)
-
-=========================================================================
-
-Bootstrap
-http://getbootstrap.com
-Copyright (c) 2011-2014 Twitter, Inc
-License: MIT (http://opensource.org/licenses/MIT)
-Documentation License: Attribution 3.0 Unported (https://creativecommons.org/licenses/by/3.0/)
-
-=========================================================================
-
-Font Awesome
-http://fontawesome.io
-Copyright Dave Gandy
-License: MIT (http://opensource.org/licenses/MIT)
-Font License: SIL OFL 1.1 (URL: http://scripts.sil.org/OFL)
-Documentation License: CC BY 3.0 (URL: http://creativecommons.org/licenses/by/3.0/)
-
-=========================================================================
-
-Ladda
-http://lab.hakim.se/ladda/
-Copyright (C) 2013 Hakim El Hattab, http://hakim.se
-License: MIT (http://opensource.org/licenses/MIT)
-
-=========================================================================
-
-d3.js
-http://d3js.org
-Copyright (c) 2012, Michael Bostock
-All rights reserved.
-License: https://github.com/mbostock/d3/blob/master/LICENSE
-
-=========================================================================
-
-nvd3.js
-http://nvd3.org
-Copyright (c) 2011-2014 Novus Partners, Inc., http://www.novus.com
-License: Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
-
-=========================================================================
-
-angularjs-nvd3-directives
-http://angularjs-nvd3-directives.github.io/angularjs-nvd3-directives/
-Copyright (c) 2013 Christian Maurer
-License: Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
-
-=========================================================================
-
+Crate licenses this software to you under the Apache License, Version 2.0.
+However, if you have executed another commercial license agreement with Crate
+these terms will supersede the license and you may use the software solely
+pursuant to the terms of the relevant commercial agreement.


### PR DESCRIPTION
following the official Apache guide:

http://www.apache.org/dev/licensing-howto.html

steps I took:

- started from two files:
  - LICENCE containing an unmodified version of the Apache License 2.0
  - NOTICE containing the standard Crate.io legal boilerplate
- added copyright and license information for "bits we're bundling" to the end of the LICENSE file
  - this meant moving some stuff from bootstrap.py (which is totally fine, and I left a note there, as is required by their licence)
  - it also meant dropping many of the things we were already listing, because, I poked around, and as far as I can tell, we are not directly "bundling those bits". we rely on the end user to fetch those bits when she is building the project. so there's no requirement for us to mention them in these files

this is just the first PR

I will not follow a similar process to fix up crate/crate-docs-theme and crate/crate