### PR TITLE
remove trailing space when selecting a column name in table detail view

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Remove trailing space from column name in tables detail view.
+
  - Fixed light theme colors. Removed unused variables.
 
  - Show column data types in table schema in upper case.

--- a/app/views/table-detail.html
+++ b/app/views/table-detail.html
@@ -189,7 +189,7 @@
       </div>
       <div class="table-schema__detail">
         <div class="table-schema__detail__row" ng-repeat="row in schemaRows track by $index">
-            <div class="table-schema__detail__cell"> {{ row.column_name }}
+            <div class="table-schema__detail__cell"> <span>{{ row.column_name }}</span>
               <div ng-if="row.is_generated" class="generation-expression"> AS {{ row.generation_expression }} </div>
               <a class="generation-expression--help" ng-if="row.is_generated" target="_blank" href="https://crate.io/docs/crate/reference/sql/ddl/generated_columns.html"><i class="fa fa-question-circle" aria-hidden="true" ></i></a>
             </div>


### PR DESCRIPTION
removed trailing space when selecting a column name in table detail view.

before: 
http://g.recordit.co/qPPYdLz25W.gif
after: 
http://g.recordit.co/bceb6HUSfR.gif 

related to : https://github.com/crate/crate-admin/issues/559