### PR TITLE
Fixed several issues concerning table/view filtering

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+ - Fixed several bugs concerning filtering tables/views where table
+   information would not be updated properly. Also fixed the clear filter
+   button for both table and view filtering.
+
  - Removed abbreviations in the overview and table view. Updated nodes view.
 
  - Remove trailing space from column name in tables detail view.

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -336,6 +336,10 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
           return false;
         };
 
+        $scope.clearFilter = function () {
+            $scope.query = '';
+        };
+
         function updateTableList() {
             $scope.tables = [];
             var tables = ClusterState.data.tables;

--- a/app/scripts/controllers/views.js
+++ b/app/scripts/controllers/views.js
@@ -158,6 +158,10 @@ angular.module('views', ['stats', 'sql', 'common', 'viewinfo', 'events'])
           return (!$scope.search || (item.fqn.toLowerCase().indexOf($scope.search) != -1));
         };
 
+        $scope.clearFilter = function () {
+            $scope.search = '';
+          };
+
         $scope.isActive = (schema, name) => {
           return name === $state.params.name && schema === $state.params.schema;
         };

--- a/app/views/tablelist.html
+++ b/app/views/tablelist.html
@@ -3,7 +3,7 @@
     <div class="filter__wrapper">
 
         <input id="tableFilter" ng-model="query" placeholder="Filter tables ..." type="text">
-        <a ng-if="query" class="cr-clear-filters" ng-click="query = '' ">
+        <a ng-if="query" class="cr-clear-filters" ng-click="clearFilter()">
             <i class="fa fa-times-circle" aria-hidden="true"></i>
         </a>
         <div>
@@ -27,18 +27,18 @@
 
         <div class="tables-list" id="tables-list--{{$index}}" ng-class="{'collapse': isCollapsed($index), 'in': !isCollapsed($index)}">
           <div class="side-bar__element tables-list__element" ng-class="{ 'active': isActive(table.table_schema, table.name)}" ng-if="renderSidebar" ng-repeat="table in type.tables | filter:table_filter track by $index">
-            <a href="#!/tables/{{:: table.table_schema }}/{{:: table.name }}">
+            <a href="#!/tables/{{ table.table_schema }}/{{ table.name }}">
               <div class="table-name-row">
                 <div class="table-name">
                   <h3>{{ table.name }}</h3>
                 </div>
                 <div class="table-health">
-                  <span class="health-bubble {{:: table.health_panel_class }}" title="{{:: table.health.status }}"></span>
+                  <span class="health-bubble {{ table.health_panel_class }}" title="{{ table.health.status }}"></span>
                 </div>
               </div>
               <div class="table-information">
                 <span>{{ table.records_total|roundWithUnit:1 }}
-                  {{ 'TABLE.RECORDS' | translate }} ({{:: table.size|bytes }})</span>
+                  {{ 'TABLE.RECORDS' | translate }} ({{ table.size|bytes }})</span>
                 <span><br>{{ table.summary }}</span>
               </div>
             </a>

--- a/app/views/viewlist.html
+++ b/app/views/viewlist.html
@@ -2,7 +2,7 @@
 
   <div class="filter__wrapper">
     <input id="tableFilter" ng-model="search" placeholder="Filter views ..." type="text" focus="true" />
-    <a ng-if="search" class="cr-clear-filters" ng-click="search = '' ">
+    <a ng-if="search" class="cr-clear-filters" ng-click="clearFilter()">
       <i class="fa fa-times-circle" aria-hidden="true"></i>
     </a>
     <div>
@@ -31,7 +31,7 @@
            ng-class="{ 'active': isActive(view.schema, view.name)}"
            ng-if="renderSidebar"
            ng-repeat="view in type.views | filter:viewFilter track by $index"
-           href="#!/views/{{:: view.schema }}/{{:: view.name }}">
+           href="#!/views/{{ view.schema }}/{{ view.name }}">
           <h4>{{ view.name }}</h4>
         </a>
       </div>


### PR DESCRIPTION
When filtering the table/view list, the incorrect link, table status and table size would be preserved from what was previously in that position in the table/view list. This fix changes this so that the links/status/size are updated as we would expect.

The clear filter button also was not working. This has also been fixed.

This should fix #560 