### PR TITLE
fixed an issue that caused timestamp to not be formatted correctly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+Fixes
+-----
+
+- Fixed an issue that caused timestamp to not be formatted correctly.
+
 2019/03/20 1.12.0
 =================
 

--- a/app/scripts/filter/text.js
+++ b/app/scripts/filter/text.js
@@ -75,6 +75,10 @@ const filters_text = angular.module('filters_text', [])
   })
   .filter('formatTimestamp', function() {
     return function(timestamp) {
+      var is_valid = timestamp == 0 || (new Date(timestamp)).getTime() > 0;
+      if (!is_valid) {
+        return "Invalid Timestamp";
+      }
       return new Date(timestamp).toISOString();
     };
   });

--- a/app/tests/filter/text.test.js
+++ b/app/tests/filter/text.test.js
@@ -90,5 +90,13 @@ describe('formatTimestamp', function() {
 		var milliseconds = new Date(0);
 		expect(formatTimestamp(milliseconds.getTime())).toBe("1970-01-01T00:00:00.000Z");
 	});
+
+	it('should return invalid', function() {
+		var formatTimestamp;
+		formatTimestamp = $filter('formatTimestamp');
+		var timestamp = 9223372036854776000;
+		var value = formatTimestamp(timestamp);
+		expect(value).toBe("Invalid Timestamp");
+	});
 });
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
