### PR TITLE
Rename schema_name to tables_schema in tables partion query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+
+2019/07/10 1.15.1
+=================
+
+Fixes
+-----
+
+- Adapted a query for compatibility with the upcoming CrateDB 4.0 release.
+
+
 2019/04/03 1.15.0
 =================
 
@@ -13,6 +23,7 @@ Breaking Changes
 
 - Adapted a query for compatibility with the upcoming CrateDB 4.0 release. This
   drops the compatibility with earlier CrateDB versions.
+
 
 2019/03/25 1.14.0
 =================

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -108,7 +108,7 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
 
         const PARTITION_QUERY = 'SELECT partition_ident, number_of_shards, number_of_replicas, values ' +
           'FROM information_schema.table_partitions ' +
-          'WHERE schema_name = ? AND table_name = ? AND closed = false';
+          'WHERE table_schema = ? AND table_name = ? AND closed = false';
 
         const COLUMN_QUERY = 'SELECT column_name, upper(data_type) as data_type, is_generated, generation_expression ' +
           'FROM information_schema.columns ' +


### PR DESCRIPTION
information_schema.table_partitions.schema_name was renamed
to information_schema.table_partitions.table_schema in CrateDB
4.0.0

## Summary of the changes / Why this is an improvement


## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
