### PR TITLE
Adapt column query for `is_generated` change in CrateDB 4.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed the table/column display to no longer display all columns as being
+  generated columns.
+
 - Replaced the Slack icon with Discourse in the help section, updated nametags
   for all languages and translations for Spanish.
 

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -110,9 +110,17 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
           'FROM information_schema.table_partitions ' +
           'WHERE table_schema = ? AND table_name = ? AND closed = false';
 
-        const COLUMN_QUERY = 'SELECT column_name, upper(data_type) as data_type, is_generated, generation_expression ' +
-          'FROM information_schema.columns ' +
-          'WHERE table_schema = ? AND table_name = ?';
+        const COLUMN_QUERY = `
+SELECT
+    column_name,
+    upper(data_type) AS data_type,
+    is_generated = 'ALWAYS' as is_generated,
+    generation_expression
+FROM
+    information_schema.columns
+WHERE
+    table_schema = ?
+    AND table_name = ?`;
 
         var requestId = function () {
           return 'r-' + new Date().getTime() + '-' + Math.floor(Math.random() * 1000);


### PR DESCRIPTION
is_generated changed in 4.0 from a boolean to a string (`ALWAYS`,
`NEVER`) to conform to the SQL standard.

Fixes https://github.com/crate/crate-admin/issues/634