### PR TITLE
Fixed an issue that cause the twitter tutorial to not be automatically started

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed an issue that caused the Twitter tutorial to not start automatically
+  after the login redirect.
+
 2019/09/16 1.15.2
 =================
 

--- a/app/plugins/tutorial/tutorial.js
+++ b/app/plugins/tutorial/tutorial.js
@@ -45,9 +45,9 @@ angular.module('tutorial', ['sql', 'translation'])
           tweet.retweeted,
           tweet.source,
           tweet.text,
-          tweet.user], 
+          tweet.user],
           false,
-          false, 
+          false,
           false,
           false);
       };
@@ -196,7 +196,7 @@ angular.module('tutorial', ['sql', 'translation'])
 
     NavigationService.addNavBarElement(iconSrc, $filter('translate', 'NAVIGATION.HELP'), url, position, "tutorial");
 
-    if ($window.location.search.match(re) !== null) {
+    if ($window.location.hash.match(re) !== null) {
       var path = $window.location.pathname;
       localStorage.setItem('crate.start_twitter', 'true');
       $window.location.href = path + $window.location.search.replace(re, '') + '#!' + url;


### PR DESCRIPTION

since angular router uses /#!/ the twitter query string was not found in window.location.search
it is instead found in window.location.hash

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
