### PR TITLE
Forces the query table results in the Console view to rerender when …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed an issue that caused the result table to display incorrect results in
+  certain columns after clicking the pagination buttons.
+
 - Fixed an issue that caused the Twitter tutorial to not start automatically
   after the login redirect.
 

--- a/app/views/console.html
+++ b/app/views/console.html
@@ -98,9 +98,9 @@
 
                   <pre class="query-result string" ng-switch-when="timestamp">{{ column.value }} <span class="formatted-timestamp">({{ column.value | formatTimestamp }})</span></pre>
 
-                  <pre class="query-result" ng-switch-when="array" ><formatted-array array="column.value" typesarray="{{resultHeaderTypes[$index]}}" expand="true"></formatted-array></pre>
+                  <pre class="query-result" ng-switch-when="array" ><formatted-array array="column.value" typesarray="{{resultHeaderTypes[$index]}}" expand="false"></formatted-array></pre>
 
-                  <pre class="query-result" ng-switch-when="object"><formatted-object object="column.value" expand="true"></formatted-object></pre>
+                  <pre class="query-result" ng-switch-when="object"><formatted-object object="column.value" expand="false"></formatted-object></pre>
 
                   <pre class="query-result object" ng-switch-when="geo_shape"><span>Type</span>: {{ column.value['type']}} <a ng-href="http://geojson.io/#data=data:application/json,{{urlEncodedJson(column)}}" target="_blank"><i class="fa fa-external-link"></i></a><br/><span>Coordinates</span>: {{ column.value['coordinates'] }} </pre>
                   <pre ng-switch-default class="query-result" ng-class="column.type"><code class="cr-table-cell--max-width">{{column.value }}<span class="unsafe-number" data-original-title="{{'CONSOLE.UNSAFE_INTEGER' | translate }}" cr-tooltip cr-tooltip-position="right" ng-if="!ColumnTypeCheck.isSafe(column.value)"><i class="fa fa-exclamation-triangle" aria-hidden="true"></i></span></code></pre>


### PR DESCRIPTION
clicking on previous/next buttons

uses safeApply to force the $digest cycle and re-render the page

Object and Arrays are not expanded by default.
When the panigation next/previous are clicked, all objects and arrays are closed.
This forces the UI to not reuse DOM elements, when the user expands an object or array the ng-if ensure that correct data is rendered. 

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
