### PR TITLE
removed unnecessary z-index from pagination header.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed an issue that caused the pagination button styling to break.
+
 - Fixed an issue that caused the result table to display incorrect results in
   certain columns after clicking the pagination buttons.
 

--- a/app/styles/views/_console.scss
+++ b/app/styles/views/_console.scss
@@ -125,7 +125,6 @@
 	position: -o-sticky;
 	position: sticky;
 	top: 40px;
-	z-index: 23 !important;
 
 	display: flex;
 	flex-direction: row;


### PR DESCRIPTION
setting position:sticky already stacks the header on top of other elements

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
