### PR TITLE
Fix partitioned by column value display

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Fixes
 -----
 
+- Fixed an issue that caused a ``0`` value for the partitioned by column of a
+  table to be displayed as ``NULL`` instead.
+
 - Fixed an issue that caused the node health to not be displayed in the Cluster 
   View when the node name was too large.
 

--- a/app/views/table-detail.html
+++ b/app/views/table-detail.html
@@ -160,7 +160,7 @@
           <tr ng-repeat="item in ptCtlr.data|orderBy:ptCtlr.sort.col:ptCtlr.sort.desc track by $index">
             <td class="{{ item.health_cell_class }}">{{ item.health }}</td>
             <td>{{ item.partition_ident }}</td>
-            <td ng-repeat="col in table.partitioned_by track by $index">{{ item.partition_values[col] ? item.partition_values[col] : 'NULL' }}</td>
+            <td ng-repeat="col in table.partitioned_by track by $index">{{ item.partition_values[col] === null ? 'NULL' : item.partition_values[col] }}</td>
 
             <td>{{ item.replicas_configured }}</td>
 


### PR DESCRIPTION
`if (var)` is false for empty strings, null, undefined, false, 0 and
NaN. We want to display `NULL` only for the `null` case, not any of the
others.

Before:

![image](https://user-images.githubusercontent.com/38700/69412024-672e1d00-0d0e-11ea-9ac8-1feb3f17aefa.png)

After:


![image](https://user-images.githubusercontent.com/38700/69411971-4e256c00-0d0e-11ea-9adf-2fab6fa6ccea.png)
