### PR TITLE
Fix capitalization of shards tab label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changes for Crate Admin Interface
 =================================
 
+Fixes
+-----
+
+- Fixed capitalization of ``Shards`` tab label
+
 2019/11/22 1.15.5
 =================
 

--- a/app/plugins/shards/static/i18n/de.json
+++ b/app/plugins/shards/static/i18n/de.json
@@ -1,5 +1,5 @@
 {
   "NAVIGATION": {
-    "SHARDS": "shards"
+    "SHARDS": "Shards"
   }
 }

--- a/app/plugins/shards/static/i18n/en.json
+++ b/app/plugins/shards/static/i18n/en.json
@@ -1,5 +1,5 @@
 {
   "NAVIGATION": {
-    "SHARDS": "shards"
+    "SHARDS": "Shards"
   }
 }

--- a/app/plugins/shards/static/i18n/es.json
+++ b/app/plugins/shards/static/i18n/es.json
@@ -1,5 +1,5 @@
 {
   "NAVIGATION": {
-    "SHARDS": "shards"
+    "SHARDS": "Shards"
   }
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

It's a minor fix to keep the UI tab labels uniformed and capitalized.
Currently, all of them are started with a capital letter except `shards`.

<img width="183" alt="image" src="https://user-images.githubusercontent.com/18210256/70040789-602fc600-15bc-11ea-84b4-0834451e4c53.png">

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
