### PR TITLE
Fix value display for nested partitioned columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Fixes
 -----
 
+- Fixed an issue that prevents the value for nested partitioned columns showing
+  up in the table partitions overview.
+
 - Fixed capitalization of ``Shards`` tab label
 
 - Updated keywords list so that they are recognised and painted in red.

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -207,8 +207,7 @@ WHERE
                   var shardInfoForPartition = shardResult.filter(filterByIdent(ident));
                   var confInfoForPartition = partitionResult.filter(filterByIdent(ident));
                   if (confInfoForPartition.length === 1) {
-                    var info = new TableInfo(shardInfoForPartition,
-                      confInfoForPartition[0].number_of_shards);
+                    var info = new TableInfo(shardInfoForPartition, confInfoForPartition[0].number_of_shards);
                     var o = info.asObject();
                     o.partition_values = confInfoForPartition[0].values;
                     o.partition_ident = ident;

--- a/app/scripts/services/tableinfo.js
+++ b/app/scripts/services/tableinfo.js
@@ -7,9 +7,16 @@ const tableinfo = angular.module('tableinfo', ['sql'])
     var isActiveShard = function(shard) {
       return ACTIVE_SHARDS.indexOf(shard.routing_state) > -1;
     };
+
+    var dotNotationToSubscript = function (column) {
+      return column.replace(/\.([a-zA-Z]+)/g, function(match, p1, offset, str) {
+        return `['` + p1 + `']`; 
+      });
+    };
+
     return function(arg1, arg2, arg3, arg4) {
       var shards = arg1 ? angular.copy(arg1) : [];
-      var partitionedBy = arg3 ? angular.copy(arg3) : [];
+      var partitionedBy = arg3 ? angular.copy(arg3).map(dotNotationToSubscript) : [];
       var partitioned = partitionedBy.length > 0;
       var numShardsConfigured = arg2 || 0;
       var recovery = arg4 || [];


### PR DESCRIPTION
The partitioned by columns are fetched from `information_schema.tables`
where the column names use a dot notation:

    select partitioned_by from information_schema.tables where table_name = 'test';
    +----------------+
    | partitioned_by |
    +----------------+
    | ["pk.part"]    |
    +----------------+

These column names were then used to lookup the value from the `values`
in `information_schema.table_partitions`, but there the columns have the
subscript notation:

    select values from information_schema.table_partitions where table_name = 'test';
    +---------------------+
    | values              |
    +---------------------+
    | {"pk['part']": "x"} |
    +---------------------+

Fixes https://github.com/crate/crate-admin/issues/657