### PR TITLE
Tweet tutorial table no longer uses deprecated column types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changes for Crate Admin Interface
 =================================
 
+Unreleased
+==========
+
+Changes
+-------
+
+- Updated the Tweet tutorial table to no longer use deprecated column types.
+
 2020-07-01 1.16.0
 =================
 

--- a/app/plugins/tutorial/tutorial.js
+++ b/app/plugins/tutorial/tutorial.js
@@ -15,20 +15,20 @@ angular.module('tutorial', ['sql', 'translation'])
     var Twitter = function() {
 
       var createStmt = 'create table if not exists tweets ( ' +
-        '  id string primary key, ' +
-        '  created_at timestamp, ' +
-        '  text string INDEX using fulltext, ' +
-        '  source string INDEX using fulltext, ' +
+        '  id text primary key, ' +
+        '  created_at timestamp with time zone, ' +
+        '  text text INDEX using fulltext, ' +
+        '  source text INDEX using fulltext, ' +
         '  retweeted boolean, ' +
         '  account_user object(strict) as ( ' +
-        '    created_at timestamp, ' +
+        '    created_at timestamp with time zone, ' +
         '    verified boolean, ' +
         '    followers_count integer, ' +
-        '    id string, ' +
+        '    id text, ' +
         '    statuses_count integer, ' +
-        '    description string INDEX using fulltext, ' +
+        '    description text INDEX using fulltext, ' +
         '    friends_count integer, ' +
-        '    location string INDEX using fulltext ' +
+        '    location text INDEX using fulltext ' +
         '  ) ' +
         ') with (number_of_replicas = \'0-all\')';
       var insertStmt = 'insert into tweets ' +

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,1 +1,3 @@
 from crate.theme.rtd.conf.crate_admin_ui import *
+
+html_extra_path = []


### PR DESCRIPTION
This, previously, would cause deprecated error messages on the CrateDB node due to the use of the `TIMESTAMP` type.