### PR TITLE
Upgrade to new build 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .build
 .clone
-.crate-docs-build
+.crate-docs
 .DS_Store
 .env
 .idea/

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,8 @@ pull_request_rules:
       - label=ready-to-merge
       - '#approved-reviews-by>=1'
       - status-success=continuous-integration/travis-ci/pr
+      - status-success~=Build docs
+      - status-success~=docs/readthedocs.org
     name: default
   - name: Delete branch after merge
     actions:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,8 +26,8 @@
 DOCS_DIR      := docs
 TOP_DIR       := ..
 BUILD_JSON    := build.json
-BUILD_REPO    := https://github.com/crate/crate-docs-build.git
-CLONE_DIR     := .crate-docs-build
+BUILD_REPO    := https://github.com/crate/crate-docs.git
+CLONE_DIR     := .crate-docs
 SRC_DIR       := $(CLONE_DIR)/src
 SELF_SRC      := $(TOP_DIR)/src
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.3.3"
+  "message": "0.4.0"
 }


### PR DESCRIPTION
this PR is a sub-task of https://github.com/crate/tech-writing-domain/issues/353

changes:

- Pins the docs-build to 0.4.0
- Updates the Mergify configuration to require the docs tests (added in https://github.com/crate/crate-admin/commit/68824e2aaab2fa334159eb37c2baa69ea7f5141b)