### PR TITLE
Replace Travis CI docs tests with GitHub Actions workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: docs
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation:
+    name: Build docs on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Build docs
+        run: |
+          cd docs && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,14 @@
 notifications:
   email: false
-
-code: &code
-  stage: "Code"
-  language: node_js
-  before_install:
-    - pip install --user codecov
-  before_script:
-    - "npm install"
-  script:
-    - npm run travis
-  branches:
-    except:
-      - /.*\/.*/
-
-docs: &docs
-  stage: "Documentation"
-  language: generic
-  script:
-    - cd docs && make check
-
-matrix:
-  include:
-
-    - <<: *code
-      name: "Node 8.9.0"
-      node_js:
-      - '8.9.0'
-
-    - <<: *docs
-      name: "Python 3.7"
-      dist: xenial
-      addons:
-        apt:
-          sources:
-            - deadsnakes
-          packages:
-            - python3.7-dev
-            - python3.7-venv
-    - <<: *docs
-      name: "Python 3.7"
-      os: osx
-      osx_image: xcode10.2
+language: node_js
+node_js:
+  - '8.9.0'
+before_install:
+- pip install --user codecov
+before_script:
+  - "npm install"
+script:
+  - npm run travis
+branches:
+  except:
+    - /.*\/.*/


### PR DESCRIPTION
replace Travis CI (docs tests only) with GitHub Actions workflow - based on https://github.com/crate/crash/pull/341#issuecomment-700773923

This change reverts `.travis.yml` to the version prior to the addition of the
docs tests (i.e., bdbaa967d31c43d3ec35bd9457c6b5cbd1c30a3c).

todo list:

- [ ] merge this PR
- [ ] enable GitHub Actions workflow branch protection
