### PR TITLE
Tutorial: Use "cratedb" tag when linking to Stack Overflow

### DIFF
--- a/app/plugins/tutorial/tutorial.html
+++ b/app/plugins/tutorial/tutorial.html
@@ -10,7 +10,7 @@
     <div class="cr-panel-block--help">
       <h2>{{:: 'HELP.TITLE' | translate }} </h2>
       <div class="help-sources__wrapper">
-        <a class="help__item" href="https://stackoverflow.com/tags/crate">
+        <a class="help__item" href="https://stackoverflow.com/tags/cratedb">
           <div class="help__item__icon"><img src="static/plugins/tutorial/static/icons/icon-stackoverflow.svg"/></div>
           <div class="help__item__content">
             <h3 class="help__item__content_title">{{:: 'HELP.STACK_OVERFLOW_TITLE' | translate}}</h3>


### PR DESCRIPTION
Hi there,

while I recognize CrateDB has been conceived before the advent of Rust's Cargo package manager and its ecosystem of Crates, we might want to adjust to reality that the tags on Stack Overflow associated with `crate` are more related to Rust these days and update this to use the tag `cratedb` instead. [1] shows that this space is already well populated.

While it might still be appropriate to use filesystem locations like `/var/lib/crate` to refer to directories where CrateDB is operated within local namespaces (https://github.com/crate/crate-howtos/pull/268), we should adjust this on public spaces like Stack Overflow in order to educate ourselves and our users.

With kind regards,
Andreas.

[1] https://stackoverflow.com/tags/cratedb
