### PR TITLE
Remove misguided redirects which may lose queries currently being typed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
-- Align with license change. Enterprise features are now available to everyone.
+- Removed misguided redirects which may lose queries currently being typed.
+
+- Aligned with license change. Enterprise features are now available to everyone.
 
 - Fixed translations. French now works again.
 

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -271,13 +271,6 @@ WHERE
                 fetchPartitions();
               }
 
-              // redirect to URL of first table in list
-              // if URL does not match expected table URL
-              var expectedUrl = '/tables/' + current.table_schema + '/' + current.name;
-              if ($location.$$url !== expectedUrl) {
-                $location.url(expectedUrl);
-              }
-
             } else {
               $scope.table = null;
               $scope.renderSchema = false;

--- a/app/scripts/controllers/views.js
+++ b/app/scripts/controllers/views.js
@@ -119,12 +119,6 @@ angular.module('views', ['stats', 'sql', 'common', 'viewinfo', 'events'])
             $scope.view = current;
             $scope.view.label = current.schema + '.' + current.name;
 
-            // redirect to URL of first view in list
-            // if URL does not match expected view nURL
-            var expectedUrl = '/views/' + current.schema + '/' + current.name;
-            if ($location.$$url !== expectedUrl) {
-              $location.url(expectedUrl);
-            }
           } else {
             $scope.view = null;
             $scope.columns = [];


### PR DESCRIPTION
Hi there,

@faymarie reported #700 the other day, thank you. This patch might fix it.

I believe the selection of the "current" table/view has gotten new code already. Having redirection code in a function which gets called when registered to the `STATE_REFRESHED` event is probably a bad idea as exactly this might produce the observed behavior.

While everything should usually be fine, I can imagine an edge case where this event handler will not get detached when the page/view object is destroyed by navigating to another page. In this case, the event might fire in the background when a new table is added by another arbitrary operation potentially run by another user. And - there you go - the UI will swap out the current page and display the "Tables" page.

As I haven't been able to observe any noticeable difference in UI behavior after removing those lines of code, I am assuming it will be safe to delete it. However, I will be happy to learn otherwise. Still, I am inclined to believe that if we really need that kind of mechanism, it should be implemented differently instead of issuing a client-side redirect by updating the `location.url` attribute.

With kind regards,
Andreas.

cc @faymarie, @quodt
