### PR TITLE
Use crate-docs version 1.0.0 and add a suggestion from prose linting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Build docs
         run: |
           cd docs && make check

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ CrateDB Admin UI
 
 An admin user interface (UI) for `CrateDB`_.
 
-The admin interface is bundled with every CrateDB distribution. There is no need
-to install it separately unless you are contributing to the project.
+The admin interface is bundled with every CrateDB distribution. Unless you are
+contributing to the project, there is no need to install it separately.
 
 .. image:: docs/_assets/img/admin-ui.png
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "0.4.0"
+  "message": "1.0.0"
 }


### PR DESCRIPTION
Hi Naomi,

this patch will bring the new 1.0.0 release of `crate-docs` to `crate-admin`. Vale's prose linter tripped and I've implemented its suggestion. Good job.

With kind regards,
Andreas.