### PR TITLE
adapt table render function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,6 @@ jobs:
           #       still do it because it will yield tremendous speed improvements.
           #       By adding the `node-version` to the cache key, it should work.
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install package
         run: npm install

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Unreleased
 
 - Fixed missing whitespace.
 
+- When navigating from table view to console, apply server-side ``quote_ident``
+  function to get better usability for column names within the manifested SQL
+  statement. Also, added appropriate newlines.
+
 
 2020-10-12 1.17.0
 =================

--- a/app/scripts/controllers/tables.js
+++ b/app/scripts/controllers/tables.js
@@ -112,7 +112,7 @@ angular.module('tables', ['stats', 'sql', 'common', 'tableinfo', 'events'])
 
         const COLUMN_QUERY = `
 SELECT
-    column_name,
+    quote_ident(column_name) as column_name,
     upper(data_type) AS data_type,
     is_generated = 'ALWAYS' as is_generated,
     generation_expression
@@ -156,11 +156,11 @@ WHERE
             var filtered_columns = rows.filter(function (row) {
               return !isNestedColumn(row.column_name);
             }).map(function (row) {
-              return '"' + row.column_name + '"';
+              return row.column_name;
             });
-
-            query += filtered_columns.join(',');
-            query += ' FROM "' + tableSchema + '"."' + tableName + '" LIMIT 100;';
+            
+            query += filtered_columns.join(', ');
+            query += '\nFROM "'+ tableSchema + '"."' + tableName + '"\nLIMIT 100;';
             return query;
           };
 

--- a/app/scripts/controllers/views.js
+++ b/app/scripts/controllers/views.js
@@ -54,7 +54,7 @@ angular.module('views', ['stats', 'sql', 'common', 'viewinfo', 'events'])
         ClusterEventsHandler, ClusterState) {
 
         const NESTED_COL_REGEX = /([^\s]+)(\[\'([^\s]+)\'])+/i;
-        const COLUMNS_QUERY = 'SELECT column_name, upper(data_type) AS column_type ' +
+        const COLUMNS_QUERY = 'SELECT quote_ident(column_name) as column_name, upper(data_type) AS column_type ' +
           'FROM information_schema.columns ' +
           'WHERE table_schema = ? AND table_name = ?';
 


### PR DESCRIPTION
add quoteIdent() and isReservedKeyword()

## Summary of the changes / Why this is an improvement
closes #714 

- ~~Add quoteIdent function to table controller~~
- ~~Add isReservedKeyword function to table controller~~
- ~~Adapt render function to use quoteIdent to only quote identifiers when needed~~
- Add new lines before `FROM` and `LIMIT` in render function
- Add whitespace between identifiers
- Use server-side `quote_ident()` function when fetching column-names

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
