### PR TITLE
Remove `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-*.rst @crate/tech-writing
-docs/ @crate/tech-writing


### PR DESCRIPTION
The `@crate/tech-writing` team no longer exists.
