### PR TITLE
Rename default branch to "main"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on:
   pull_request: ~
   push:
     branches:
-      - master
+      - main
 
 jobs:
   documentation:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   tests:
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -214,9 +214,9 @@ configured branch is updated.
 To make changes to the RTD configuration (e.g., to activate or deactivate a
 release version), please contact the `@crate/tech-writing`_ team.
 
-.. |docs-version| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrate-admin%2Fmaster%2Fdocs%2Fbuild.json
+.. |docs-version| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcrate-admin%2Fmain%2Fdocs%2Fbuild.json
     :alt: Documentation version
-    :target: https://github.com/crate/crate-admin/blob/master/docs/build.json
+    :target: https://github.com/crate/crate-admin/blob/main/docs/build.json
 
 .. _@crate/tech-writing: https://github.com/orgs/crate/teams/tech-writing
 .. _Admin UI Release Preflight: https://github.com/crate/crate-admin/wiki/Admin-UI-Release-Preflight

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Looking for more help?
     :alt: Test status
     :target: https://github.com/crate/crate-admin/actions?workflow=Tests
 
-.. |test-coverage| image:: https://codecov.io/gh/crate/crate-admin/branch/master/graph/badge.svg
+.. |test-coverage| image:: https://codecov.io/gh/crate/crate-admin/branch/main/graph/badge.svg
     :alt: Test coverage
     :target: https://codecov.io/gh/crate/crate-admin
 


### PR DESCRIPTION
Hi there,

following some other repositories, this patch will rename the default branch to `main`. Is there any other thing to do beyond merging this and actually renaming the branch on GitHub, @norosa?

With kind regards,
Andreas.