### PR TITLE
improvements to console / codemirror configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
 
 - Remove all analytics (UDC, Segment) completely
 - Remove "Notifications" section in statusbar
+- Remove min-width for columns in console to reduce scrolling
+- Change syntax highlighting in console. Keywords in double quotes are now longer
+  highlighted. Types are highlighted with a different color.
+- Activate codemirror code hints for keywords
 
 2021-03-19 1.18.0
 =================

--- a/app/scripts/controllers/console.js
+++ b/app/scripts/controllers/console.js
@@ -496,8 +496,32 @@ const crate_console = angular.module('console', ['sql', 'datatypechecks', 'stats
            'while', 'width_bucket', 'window', 'with', 'within', 'without',
            'work', 'write', 'ws', 'year', 'zone'
         ]),
+          builtin: KeywordObjectCreator.create([
+            'array', 'bigint', 'binary', 'bit', 'boolean', 'byte', 'char',
+            'character', 'date', 'decimal', 'double', 'float', 'geo_point',
+            'geo_shape', 'int', 'integer', 'interval', 'int2', 'int4', 'int8',
+            'ip', 'long', 'name','numeric', 'object', 'oid', 'oidvector',
+            'precision', 'real', 'regclass', 'regproc', 'short', 'smallint',
+            'string','text', 'timestamp', 'time', 'timetz', 'timestamptz',
+            'varbinary', 'varchar', 'varying', 'with', 'without', 'zone'
+          ]),
+          dateSQL: KeywordObjectCreator.create(['date','time','timestamp']),
+          atoms: KeywordObjectCreator.create(['false','true','null']),
           operatorChars: /^[*+\-%<>!=~]/,
+          hooks : {
+            "\"":   hookIdentifierDoublequote
+          }
         });
+
+        // Needed in order to prevent identifiers to be marked as keyword
+        // see https://github.com/codemirror/CodeMirror/blob/9b81d0fd9f64972e922bb3f27ec721a9ad6a771a/mode/sql/sql.js#L227
+        function hookIdentifierDoublequote(stream) {
+          var ch;
+          while ((ch = stream.next()) != null) {
+            if (ch == "\"" && !stream.eat("\"")) return null;
+          }
+          return null;
+        }
 
         var editor = window.CodeMirror.fromTextArea(input, {
           mode: 'text/x-cratedb',
@@ -506,7 +530,9 @@ const crate_console = angular.module('console', ['sql', 'datatypechecks', 'stats
           // indent using spaces
           indentWithTabs: false,
           indentUnit: 2,
-          tabSize: 2
+          tabSize: 2,
+          hint: window.CodeMirror.hint.sql,
+          showHint: true
         });
 
         // map the Tab key to insert spaces instead of a tab character
@@ -514,7 +540,8 @@ const crate_console = angular.module('console', ['sql', 'datatypechecks', 'stats
           Tab: function (cm) {
             var spaces = ' '.repeat(cm.getOption('indentUnit'));
             cm.replaceSelection(spaces);
-          }
+          },
+          "Ctrl-Space":"autocomplete"
         });
 
         function updateStatementOnUrlSearch() {

--- a/app/styles/styles.scss
+++ b/app/styles/styles.scss
@@ -13,6 +13,7 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 
 @import '~font-awesome/css/font-awesome.css';
 @import '~codemirror/lib/codemirror.css';
+@import '~codemirror/addon/hint/show-hint.css';
 @import '~codemirror/theme/monokai.css';
 @import '~nvd3/build/nv.d3.css';
 

--- a/app/styles/views/_console.scss
+++ b/app/styles/views/_console.scss
@@ -178,7 +178,6 @@ tr > .cr-table-cell {
 }
 .cr-table-cell--max-width {
 	max-width: 400px;
-	min-width: 300px;
 	word-wrap: break-word !important;
 	display: block;
 	overflow-wrap: break-word !important;
@@ -239,7 +238,26 @@ tr > .cr-table-cell {
 	border-right: 1px solid $block-border;
 }
 
+.CodeMirror-hints {
+	background-color: $block-bg;
+	color: $text-color;
+	font-size: 100%;
+}
+
+.CodeMirror-hint {
+	color:  $text-color;
+}
+
+li.CodeMirror-hint-active {
+	color: $link-hover-color;
+	background-color: $block-bg;
+}  
+
 .cm-keyword {
+	text-transform: uppercase;
+}
+
+.cm-builtin {
 	text-transform: uppercase;
 }
 

--- a/app/vendor.module.js
+++ b/app/vendor.module.js
@@ -9,6 +9,9 @@ window.$ = $;
 
 // import 'CodeMirror';
 import CodeMirror from 'codemirror/lib/codemirror.js';
+import 'codemirror/mode/sql/sql';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/sql-hint';
 window.CodeMirror = CodeMirror;
 import 'bootstrap/dist/js/bootstrap.min.js';
 


### PR DESCRIPTION
- Remove min-width for columns in console to reduce scrolling
- Change syntax highlighting in console. Keywords in double quotes are now longer  highlighted. Types are highlighted with a different color.
- Activated codemirror code hints for keywords

closes #710 

## Summary of the changes / Why this is an improvement
![image](https://user-images.githubusercontent.com/23557193/122653029-44f6be00-d142-11eb-9658-6ed6068ad881.png)


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
