### PR TITLE
Use correct binary prefixes for units of data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changes for Crate Admin Interface
 =================================
 
+Unreleased
+==========
+
+- Use correct binary prefixes (e.g. KiB, MiB, GiB) for units of data in UI.
+  No change in calculation.
 
 2021-07-13 1.19.0
 =================

--- a/app/scripts/filter/numbers.js
+++ b/app/scripts/filter/numbers.js
@@ -27,7 +27,7 @@ const filters_numbers = angular.module('filters_numbers', [])
     };
   })
   .filter('bytes', function($sce) {
-    var units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    var units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
     return function(bytes, precision) {
       if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) {
         return '-';


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Use correct binary prefixes (e.g. KiB, MiB, GiB) for units of data in UI.
  No change in calculation.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
