### PR TITLE
Fix generated queries for views containing identifiers that need to be quoted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 - Use correct binary prefixes (e.g. KiB, MiB, GiB) for units of data in UI.
   No change in calculation.
 
+- Fix generated queries for views containing identifiers that need to be quoted
+
 2021-07-13 1.19.0
 =================
 

--- a/app/scripts/controllers/views.js
+++ b/app/scripts/controllers/views.js
@@ -83,10 +83,10 @@ angular.module('views', ['stats', 'sql', 'common', 'viewinfo', 'events'])
           var query = 'SELECT ';
           var cols = rows
             .filter((row) => !isNestedColumn(row.column_name))
-            .map((row) => '"' + row.column_name + '"');
+            .map((row) => row.column_name );
 
           query += cols.join(', ');
-          query += ' FROM "' + schema + '"."' + name + '" LIMIT 100;';
+          query += '\nFROM "' + schema + '"."' + name + '"\nLIMIT 100;';
           return query;
         };
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Fix generated queries for views containing identifiers that need to be quoted.
Identifiers that need to be quoted (e.g. with upper case letters or reserved keywords) were double quoted twice

This bug was introduced with https://github.com/crate/crate-admin/pull/715 😬 

@jayeff 

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
