### PR TITLE
Fix and improve release guidelines and helper program

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -149,15 +149,15 @@ To create a new release, you must:
 
 - Add the new version to ``package.json``
 
-- Add a section for the new version in the ``CHANGES.txt`` file
+- Invoke ``npm install --package-lock-only`` in order to update ``package-lock.json``
 
-- Commit your changes with a message like "prepare release x.y.z"
+- Add a section for the new version in the ``CHANGES.rst`` file
 
-- Push to origin
+- Commit your changes with a message like "Release x.y.z"
 
-- Create a tag by running ``./devtools/create_tag.sh``
+- Push to origin and create a tag by invoking ``./devtools/create_tag.sh``
 
-- Run the ``crate-admin_release`` job in Jenkins
+- Run the ``crate_admin_release`` job in Jenkins
 
 
 *************

--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -34,7 +34,7 @@ then
    exit -1
 fi
 
-echo "Fetching origin..."
+echo "Fetching origin"
 git fetch origin > /dev/null
 
 ## check if current branch is master
@@ -59,7 +59,7 @@ git fetch origin > /dev/null
 
 # get the version
 VERSION=`less package.json | grep "\"version\":" | cut -d : -f 2 | tr -d ' ",'`
-echo "found version $VERSION in package.json"
+echo "Found version $VERSION in package.json"
 
 # check if tag to create has already been created
 EXISTS=`git tag | grep $VERSION`
@@ -71,8 +71,8 @@ then
    exit -1
 fi
 
-# check if VERSION is in head of CHANGES.rst
 REV_NOTE=`grep "[0-9/]\{10\} $VERSION" CHANGES.rst`
+# Check if VERSION is in head of CHANGES.rst
 if [ -z "$REV_NOTE" ]
 then
     echo "No notes for revision $VERSION found in CHANGES.rst"
@@ -80,7 +80,7 @@ then
     exit -1
 fi
 
-echo "Creating tag $VERSION..."
+echo "Creating tag '$VERSION'"
 git tag -a "$VERSION" -m "Tag release for revision $VERSION"
-git push --tags
+git push && git push --tags
 echo "Done."

--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -71,8 +71,8 @@ then
    exit -1
 fi
 
-REV_NOTE=`grep "[0-9/]\{10\} $VERSION" CHANGES.rst`
 # Check if VERSION is in head of CHANGES.rst
+REV_NOTE=`grep "[0-9/-]\{10\} $VERSION" CHANGES.rst`
 if [ -z "$REV_NOTE" ]
 then
     echo "No notes for revision $VERSION found in CHANGES.rst"


### PR DESCRIPTION
Hi there,

I just minted release 1.19.1, which needed a few updates to the release guidelines and the `./devtools/create_tag.sh` helper program.

With kind regards,
Andreas.