### PR TITLE
side-nav: fix monitor icon color + make slightly smaller

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Side-Navigation: Adjusted size sligthly, added hover-effect on selected item,
+  added border on active item and fixed monitoring icon
+
 2021-09-01 1.19.1
 =================
 

--- a/app/plugins/monitoring/static/icons/icon-monitoring.svg
+++ b/app/plugins/monitoring/static/icons/icon-monitoring.svg
@@ -5,7 +5,7 @@
     <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Assets" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g transform="translate(-3.000000, -311.000000)" stroke="#CCCCCC">
+        <g transform="translate(-3.000000, -311.000000)" stroke="#FFFFFF">
             <g id="icon-monitoring-active" transform="translate(4.000000, 312.000000)">
                 <g id="icon-monitoring">
                     <path d="M17.1650391,0.056640625 C8.58251835,0.028605708 0,0 0,0 L0,21 L24,21 L24,0 C24,0 22.3933701,0.0300572133 21.0307685,0.0497953526 C20.5711422,0.0564533287 17.3495824,0.047035271 17.0165166,0.0497953526" id="Stroke-3" stroke-width="2"></path>

--- a/app/styles/vars/_dark-theme-variables.scss
+++ b/app/styles/vars/_dark-theme-variables.scss
@@ -144,7 +144,7 @@ $settings-wrapper-z-index:  1050;
 
 $side-nav-background-color: #444;
 $side-nav-border:           1px solid #2e2e2e;
-$side-nav-width:            80px;
+$side-nav-width:            70px;
 
 $side-nav-width-xs:         60px;
 

--- a/app/styles/vars/_light-theme-variables.scss
+++ b/app/styles/vars/_light-theme-variables.scss
@@ -146,7 +146,7 @@ $settings-wrapper-z-index:  1050;
 
 $side-nav-background-color: #444;
 $side-nav-border:           1px solid #2e2e2e;
-$side-nav-width:            80px;
+$side-nav-width:            70px;
 
 $side-nav-width-xs:         60px;
 

--- a/app/styles/views/_nav.scss
+++ b/app/styles/views/_nav.scss
@@ -17,15 +17,29 @@
 	cursor: pointer;
 
 	width: 100%;
-	padding-top: 20px;
-	padding-bottom: 20px;
+	padding-top: 18px;
+	padding-bottom: 18px;
 	text-align: center;
+}
+
+.cr-side-nav__item:hover {
+	background-color:$link-hover-color;
 }
 
 .cr-side-nav__item > img {
 	opacity: 0.4;
 
 }
+
+.cr-side-nav__item:hover > img{
+	opacity: 1.0;
+}
+
+.cr-side-nav__item--active  {
+	border-left: 3px solid $link-hover-color;
+	border-right: 3px solid transparent;
+}
+
 .cr-side-nav__item--active > img {
 	opacity: 1;
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
side-nav: fix monitor icon color + make slightly smaller + hover-effect

<img src="https://user-images.githubusercontent.com/23557193/132126770-1436cb88-2488-47dd-963f-18e4f51d2eb3.png" width="400"/>

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
