### PR TITLE
Draft: Add UDF Section

### DIFF
--- a/app/app.components.js
+++ b/app/app.components.js
@@ -8,6 +8,7 @@ import './scripts/services/health';
 import './scripts/services/stats';
 import './scripts/services/tableinfo';
 import './scripts/services/shardinfo';
+import './scripts/services/udfinfo';
 import './scripts/services/viewinfo';
 import './scripts/services/nodeinfo';
 import './scripts/services/checks';
@@ -20,6 +21,7 @@ import './scripts/controllers/feed';
 import './scripts/controllers/overview';
 import './scripts/controllers/console';
 import './scripts/controllers/tables';
+import './scripts/controllers/udfs';
 import './scripts/controllers/views';
 import './scripts/controllers/cluster';
 

--- a/app/app.module.js
+++ b/app/app.module.js
@@ -19,6 +19,8 @@ var MODULES = [
   'console',
   'tables',
   'tableinfo',
+  'udfs',
+  'udfinfo',
   'views',
   'viewinfo',
   'shardinfo',
@@ -52,6 +54,16 @@ var ROUTING = {
     'name': 'tables.table',
     'url': '/:table_schema/:table_name',
     'template': '<table-detail>',
+  },
+  '/udfs': {
+    'name': 'udfs',
+    'url': '/udfs',
+    'template': '<udfs>',
+  },
+  '/udfs/:schema/:name': {
+    'name': 'udfs.udf',
+    'url': '/:schema/:name',
+    'template': '<udf-detail>',
   },
   '/views': {
     'name': 'views',

--- a/app/app.module.js
+++ b/app/app.module.js
@@ -60,9 +60,9 @@ var ROUTING = {
     'url': '/udfs',
     'template': '<udfs>',
   },
-  '/udfs/:schema/:name': {
+  '/udfs/:schema/:name/:input_types': {
     'name': 'udfs.udf',
-    'url': '/:schema/:name',
+    'url': '/:schema/:name/:input_types',
     'template': '<udf-detail>',
   },
   '/views': {

--- a/app/scripts/controllers/common.js
+++ b/app/scripts/controllers/common.js
@@ -314,15 +314,17 @@ commons.run(function(NavigationService, $translate, $filter, $rootScope) {
   NavigationService.addNavBarElement('static/assets/icon-console.svg', $filter('translate', 'NAVIGATION.CONSOLE'), '/console', 20, "console");
   NavigationService.addNavBarElement('static/assets/icon-table.svg', $filter('translate', 'NAVIGATION.TABLE'), '/tables', 30, "tables");
   NavigationService.addNavBarElement('static/assets/icon-view.svg', $filter('translate', 'NAVIGATION.VIEW'), '/views', 40, "views");
-  NavigationService.addNavBarElement('static/assets/icon-cluster.svg', $filter('translate', 'NAVIGATION.CLUSTER'), '/nodes', 50, "nodes");
+  NavigationService.addNavBarElement('static/assets/icon-monitoring.svg', $filter('translate', 'NAVIGATION.UDF'), '/udfs', 50, "udfs");
+  NavigationService.addNavBarElement('static/assets/icon-cluster.svg', $filter('translate', 'NAVIGATION.CLUSTER'), '/nodes', 60, "nodes");
 
   // Update Navbar Elements if Language is Changed
   $rootScope.$on('$translateChangeSuccess', function() {
-    $translate(['NAVIGATION.OVERVIEW', 'NAVIGATION.CONSOLE', 'NAVIGATION.TABLE', 'NAVIGATION.VIEW', 'NAVIGATION.CLUSTER']).then(function(i18n) {
+    $translate(['NAVIGATION.OVERVIEW', 'NAVIGATION.CONSOLE', 'NAVIGATION.TABLE', 'NAVIGATION.VIEWS', 'NAVIGATION.UDF', 'NAVIGATION.CLUSTER']).then(function(i18n) {
       NavigationService.updateNavBarElement('/', i18n['NAVIGATION.OVERVIEW']);
       NavigationService.updateNavBarElement('/console', i18n['NAVIGATION.CONSOLE']);
       NavigationService.updateNavBarElement('/tables', i18n['NAVIGATION.TABLE']);
       NavigationService.updateNavBarElement('/views', i18n['NAVIGATION.VIEW']);
+      NavigationService.updateNavBarElement('/udfs', i18n['NAVIGATION.UDF']);
       NavigationService.updateNavBarElement('/nodes', i18n['NAVIGATION.CLUSTER']);
     });
   });

--- a/app/scripts/controllers/common.js
+++ b/app/scripts/controllers/common.js
@@ -319,7 +319,7 @@ commons.run(function(NavigationService, $translate, $filter, $rootScope) {
 
   // Update Navbar Elements if Language is Changed
   $rootScope.$on('$translateChangeSuccess', function() {
-    $translate(['NAVIGATION.OVERVIEW', 'NAVIGATION.CONSOLE', 'NAVIGATION.TABLE', 'NAVIGATION.VIEWS', 'NAVIGATION.UDF', 'NAVIGATION.CLUSTER']).then(function(i18n) {
+    $translate(['NAVIGATION.OVERVIEW', 'NAVIGATION.CONSOLE', 'NAVIGATION.TABLE', 'NAVIGATION.VIEW', 'NAVIGATION.UDF', 'NAVIGATION.CLUSTER']).then(function(i18n) {
       NavigationService.updateNavBarElement('/', i18n['NAVIGATION.OVERVIEW']);
       NavigationService.updateNavBarElement('/console', i18n['NAVIGATION.CONSOLE']);
       NavigationService.updateNavBarElement('/tables', i18n['NAVIGATION.TABLE']);

--- a/app/scripts/controllers/udfs.js
+++ b/app/scripts/controllers/udfs.js
@@ -1,0 +1,260 @@
+'use strict';
+
+angular.module('udfs', ['stats', 'sql', 'common', 'udfinfo', 'events'])
+  .provider('TabNavigationInfo', function () {
+    this.collapsed = [false, true]; // must match $scope.udfs of TablesController
+    this.$get = () => {
+      var collapsed = this.collapsed;
+      return {
+        'collapsed': collapsed,
+        'toggleIndex': (i) => {
+          collapsed[i] = !collapsed[i];
+        },
+        'collapseIndex': (i) => {
+          collapsed[i] = true;
+        },
+        'unCollapseIndex': (i) => {
+          collapsed[i] = false;
+        }
+      };
+    };
+  })
+  .directive('udfs', function () {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {},
+      templateUrl: 'static/views/udfs.html',
+      controllerAs: 'UdfsController',
+      controller: function (ClusterState, $scope, ClusterEventsHandler) {
+        var hideIfEmpty = () => {
+          $scope.empty = ClusterState.data.udfs.length === 0;
+        };
+
+        // initial state
+        hideIfEmpty();
+
+        ClusterEventsHandler.register('STATE_REFRESHED', 'UdfsController', hideIfEmpty);
+
+        $scope.$on('$destroy', function () {
+          ClusterEventsHandler.remove('STATE_REFRESHED', 'UdfsController');
+        });
+      }
+    };
+  })
+  .directive('udfDetail', function () {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {},
+      templateUrl: 'static/views/udf-detail.html',
+      controllerAs: 'UDFDetailController',
+      controller: function ($scope, $location, $log, $timeout, $state,
+        SQLQuery, queryResultToObjects, roundWithUnitFilter, bytesFilter, UdfList,
+        ClusterEventsHandler, ClusterState) {
+
+        const NESTED_COL_REGEX = /([^\s]+)(\[\'([^\s]+)\'])+/i;
+        const COLUMNS_QUERY = 'SELECT quote_ident(column_name) as column_name, upper(data_type) AS column_type ' +
+          'FROM information_schema.columns ' +
+          'WHERE table_schema = ? AND table_name = ?';
+
+        $scope.executeQuery = (query) => {
+          $location.search({'query': query});
+          $location.path('/console');
+        };
+
+        // sidebar button handler (mobile udf)
+        $scope.toggleSidebar = function () {
+          $('#page-viewport')
+            .toggleClass('show-sidebar');
+          $('.menu-toggle i.fa')
+            .toggleClass('fa-angle-double-right')
+            .toggleClass('fa-angle-double-left');
+        };
+
+        // bind tooltips
+        $('[rel=tooltip]').tooltip({
+          placement: 'top'
+        });
+
+        var isNestedColumn = (col) => col.match(NESTED_COL_REGEX);
+
+        var constructQuery = (schema, name, rows) => {
+          var query = 'CREATE OR REPLACE FUNCTION "' + schema + '"."' + name + '"';
+          query += '\nRETURNS ';
+          query += '\nLANGUAGE ' + 'JAVASCRIPT';
+          query += '\nAS ';
+          query += '\n\'' + 'function';
+          query += '\n\';';
+          return query;
+        };
+
+        var render = (schema, name) => {
+          $scope.nothingSelected = false;
+          $scope.renderSiderbar = true;
+
+          if (schema && name) {
+            SQLQuery.execute(COLUMNS_QUERY, [schema, name], false, false, false, false)
+              .then((q) => {
+                $scope.columns = queryResultToObjects(q, q.cols);
+                $scope.query = constructQuery(schema, name, $scope.columns);
+              }, () => {
+                $scope.columns = [];
+              });
+          }
+        };
+
+        var updateUDF = () => {
+          var name = $state.params.name;
+          var schema = $state.params.schema;
+          var udfs = ClusterState.data.udfs;
+
+          var hasUdfs = udfs.length > 0;
+          $scope.renderSidebar = hasUdfs;
+          $scope.nothingSelected = !hasUdfs;
+          if (hasUdfs) {
+            var current = udfs.filter((o) => o.name == name && o.schema == schema);
+            current = current.length ? current[0] : udfs[0];
+            $scope.udf = current;
+            $scope.udf.label = current.schema + '.' + current.name;
+
+          } else {
+            $scope.udf = null;
+            $scope.columns = [];
+          }
+        };
+
+        ClusterEventsHandler.register('STATE_REFRESHED',
+          'UDFDetailController',
+          updateUDF);
+
+        $scope.$on('$destroy', function () {
+          ClusterEventsHandler.remove('STATE_REFRESHED', 'UDFDetailController');
+        });
+
+        updateUDF();
+        render($state.params.schema, $state.params.name);
+      }
+    };
+  })
+  .directive('udfList', function () {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {},
+      templateUrl: 'static/views/udflist.html',
+      controllerAs: 'UdfListController',
+      controller: function ($scope, $state, TabNavigationInfo, ClusterEventsHandler, ClusterState) {
+        $scope.collapsed = true;
+
+        $scope.udfFilter = (item) => {
+          return (!$scope.search || (item.fqn.toLowerCase().indexOf($scope.search) != -1));
+        };
+
+        $scope.clearFilter = function () {
+            $scope.search = '';
+          };
+
+        $scope.isActive = (schema, name) => {
+          return name === $state.params.name && schema === $state.params.schema;
+        };
+
+        var toggleClasses = (i) => {
+          $('#nav-tabs-' + i)
+            .collapse('toggle');
+          $('#nav-tabs-header-' + i + ' i.fa')
+            .toggleClass('fa-caret-down')
+            .toggleClass('fa-caret-right');
+        };
+
+        $scope.toggleElements = (i) => {
+          toggleClasses(i);
+          TabNavigationInfo.toggleIndex(i);
+        };
+
+        $scope.isCollapsed = (i) => {
+          return TabNavigationInfo.collapsed[i];
+        };
+
+        $scope.collapseAll = () => {
+          var idx;
+          for (idx in $scope.udfs) {
+            toggleClasses(idx);
+            TabNavigationInfo.collapseIndex(idx);
+          }
+          $scope.collapsed = true;
+        };
+
+        $scope.unCollapseAll = () => {
+          var idx;
+          for (idx in $scope.udfs) {
+            toggleClasses(idx);
+            TabNavigationInfo.unCollapseIndex(idx);
+          }
+          $scope.collapsed = false;
+        };
+
+        var filterBySchemaName = (schema) => (o) => o.schema === schema;
+
+        var updateUdfList = () => {
+          var udfs = ClusterState.data.udfs;
+          var hasUdfs = udfs.length > 0;
+          $scope.renderSidebar = hasUdfs;
+          $scope.udfs = [];
+          if (hasUdfs) {
+            // use name and schema from first item
+            if (!$scope.name || !$scope.schema) {
+              $scope.schema = udfs[0].schema;
+              $scope.name = udfs[0].name;
+              $state.go('udfs.udf', {
+                schema: $scope.schema,
+                name: $scope.name
+              });
+            }
+
+            var idx,
+              name;
+            var customSchemas = [];
+            for (idx in udfs) {
+              name = udfs[idx].schema;
+              if (name == 'doc' || name == 'blob' || customSchemas.indexOf(name) > -1) {
+                continue;
+              }
+              customSchemas.push(name);
+            }
+
+            $scope.udfs.push({
+              display_name: 'Doc',
+              udfs: udfs.filter(filterBySchemaName('doc')),
+              schema: 'doc'
+            });
+            for (idx in customSchemas) {
+              name = customSchemas[idx];
+              $scope.udfs.push({
+                display_name: name,
+                udfs: udfs.filter(filterBySchemaName(name)),
+                schema: name
+              });
+            }
+          }
+        };
+
+        var render = (schema, name) => {
+          $scope.name = name;
+          $scope.schema = schema;
+          $scope.renderSidebar = true;
+        };
+
+        ClusterEventsHandler.register('STATE_REFRESHED',
+          'UdfListController',
+          updateUdfList);
+
+        $scope.$on('$destroy', function () {
+          ClusterEventsHandler.remove('STATE_REFRESHED', 'UdfListController');
+        });
+
+        updateUdfList();
+        render($state.params.schema, $state.params.name);
+      }
+    };
+  });

--- a/app/scripts/services/stats.js
+++ b/app/scripts/services/stats.js
@@ -8,7 +8,7 @@ import './clusterEventsHandler';
 
 const stats = angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo', 'events'])
   .factory('ClusterState', function ($http, $interval, $timeout, $log, $q, $rootScope,
-    baseURI, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo, ViewInfo, ViewList, ClusterEventsHandler) {
+    baseURI, SQLQuery, queryResultToObjects, TableList, Health, ShardInfo, NodeInfo, UdfInfo, UdfList, ViewInfo, ViewList, ClusterEventsHandler) {
     var reachabilityInterval,
       ClusterStateInterval;
 
@@ -20,6 +20,7 @@ const stats = angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo',
     var data = {
       online: true,
       tables: [],
+      udfs: [],
       views: [],
       shards: [],
       partitions: [],
@@ -166,6 +167,7 @@ const stats = angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo',
       ShardInfo.executeRecoveryStmt(),
       NodeInfo.executeClusterQuery(),
       NodeInfo.executeNodeQuery(),
+      UdfInfo.executeUdfStmt(),
       ViewInfo.executeViewStmt()
     ]).then(function (values) {
 
@@ -213,7 +215,10 @@ const stats = angular.module('stats', ['sql', 'health', 'tableinfo', 'nodeinfo',
           data.tables = tableinfo.data.tables;
         }
 
-        var viewInfo = ViewList.execute(values[6]);
+        var udfInfo = UdfList.execute(values[6]);
+        data.udfs = udfInfo.data.udfs;
+
+        var viewInfo = ViewList.execute(values[7]);
         data.views = viewInfo.data.views;
 
         ClusterEventsHandler.trigger('STATE_REFRESHED');

--- a/app/scripts/services/udfinfo.js
+++ b/app/scripts/services/udfinfo.js
@@ -1,0 +1,75 @@
+'use strict';
+import './sql';
+
+const udfinfo = angular.module('udfinfo', ['sql'])
+  .factory('UdfInfo', function($q, SQLQuery, queryResultToObjects) {
+    var udfInfo = {
+      deferred: $q.defer()
+    };
+
+    const UDFS_STMT = `SELECT
+    routine_name as "name",
+    routine_schema AS "schema",
+    format('%s.%s', routine_name, routine_schema) AS "fqn",
+    routine_definition AS "definition",
+    (regexp_replace(specific_name, '.*\\((.*)\\)', '$1')) as "input_types",
+    (data_type) AS "return_type",
+    routine_body AS "language"
+FROM information_schema.routines
+where routine_type = 'FUNCTION';
+`
+
+    const COLS = ['name', 'schema', 'fqn', 'definition', 'input_types', 'return_type', 'language'];
+
+    udfInfo.executeUdfStmt = () => {
+      var deferred = $q.defer();
+      var promise = deferred.promise;
+
+      SQLQuery.execute(UDFS_STMT, {}, false, false, false, false)
+        .then((q) => {
+          deferred.resolve(queryResultToObjects(q, COLS));
+        }, () => {
+          deferred.reject();
+        });
+
+      return promise;
+    };
+
+    return udfInfo;
+  })
+  .factory('UdfList', function() {
+
+    var data = {
+      'udfs': []
+    };
+
+    var update = (success, udfs) => {
+      if (success && udfs && udfs.length) {
+        data.udfs = udfs;
+      } else {
+        data.udfs = [];
+      }
+      return {
+        'success': success,
+        'data': data
+      };
+    };
+
+    var fetch = (udfs) => {
+      if (udfs && udfs.length) {
+        return update(true, udfs);
+      } else {
+        return update(false, []);
+      }
+    };
+
+    // initialize
+    fetch();
+
+    return {
+      'data': data,
+      'execute': fetch
+    };
+  });
+
+export default udfinfo;

--- a/app/static/i18n/en.json
+++ b/app/static/i18n/en.json
@@ -104,9 +104,8 @@
     },
     "UDF": {
         "TITLE": "UDFs",
-        "VOID_MESSAGE": "There are no udfs created yet.",
-        "VOID_DETAILS": "Use the {{ statement }} statement to create new udfs.",
-        "QUERY_UDF": "Query udf",
+        "VOID_MESSAGE": "There are no UDFs created yet.",
+        "VOID_DETAILS": "Use the {{ statement }} statement to create new UDFs.",
         "REPLACE_UDF": "Replace UDF",
         "PARAMETERS": "Parameters",
         "RETURN_TYPE": "Return Type",

--- a/app/static/i18n/en.json
+++ b/app/static/i18n/en.json
@@ -23,6 +23,7 @@
         "OVERVIEW": "Overview",
         "CONSOLE": "Console",
         "TABLE": "Tables",
+        "UDF": "User Defined Functions",
         "VIEW": "Views",
         "SHARDS": "Shards",
         "CLUSTER": "Cluster",
@@ -100,6 +101,20 @@
         "PARTITIONS": "Partitions",
         "SCHEMA": "Schema",
         "TYPE": "Type"
+    },
+    "UDF": {
+        "TITLE": "UDFs",
+        "VOID_MESSAGE": "There are no udfs created yet.",
+        "VOID_DETAILS": "Use the {{ statement }} statement to create new udfs.",
+        "QUERY_UDF": "Query udf",
+        "REPLACE_UDF": "Replace UDF",
+        "PARAMETERS": "Parameters",
+        "RETURN_TYPE": "Return Type",
+        "LANGUAGE": "Language",
+        "NAME": "Name",
+        "TYPE": "Type",
+        "DEFINITION": "Definition",
+        "COLUMNS": "Columns"
     },
     "VIEW": {
         "TITLE": "Views",

--- a/app/styles/styles.scss
+++ b/app/styles/styles.scss
@@ -39,6 +39,7 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 @import 'views/statusbar';
 @import 'views/tablelist';
 @import 'views/tables';
+@import 'views/udfs';
 @import 'views/views';
 @import 'views/nodelist';
 @import 'views/tutorial';

--- a/app/styles/views/_common.scss
+++ b/app/styles/views/_common.scss
@@ -331,6 +331,8 @@ label:hover:before {
 	border-radius: 3px;
 	background: $cr-panel-default-background !important;
 	font-family: $font-family-monospace;
+	white-space: pre;
+	word-break: normal;
 }
 
 .cr-cell--success{

--- a/app/styles/views/_udfs.scss
+++ b/app/styles/views/_udfs.scss
@@ -1,0 +1,60 @@
+.udf-detail {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	border: 1px solid $block-border;
+}
+
+.udf-detail__row {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	width: 50%;
+}
+
+.udf-detail__fullrow {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.udf-detail.cr-panel-block {
+	margin-bottom: 5px !important;
+}
+
+.udf-detail__cell {
+	width: 50%;
+	padding: 0px 15px;
+}
+
+.udf-detail__fullcell {
+	width: 100%;
+	padding: 0px 15px;
+}
+
+.udf-detail__cell-title {
+	font-weight: 700;
+}
+
+.udf-detail__cell-content {
+	padding: 6px;
+	border-radius: 3px;
+	border: 1px solid $block-border;
+}
+
+@media only screen and (max-width : $max-width-m) {
+
+	.udf-detail__row {
+		width: 100%;
+	}
+
+}
+
+@media only screen and (max-width : $max-width-xs) {
+
+	.udf-detail__cell {
+		width: 100%;
+	}
+
+}

--- a/app/views/udf-detail.html
+++ b/app/views/udf-detail.html
@@ -1,0 +1,61 @@
+<div class="page-container" ng-class="{'page-container-padded': renderSidebar, 'page-container--no-list': !$root.showSideList}">
+  <div ng-show="udf">
+
+    <h1>{{ 'NAVIGATION.UDF' | translate }}</h1>
+
+    <div class="udf-detail cr-panel-block">
+      <div class="udf-detail__row">
+        <div class="udf-detail__cell">
+          <div class="cr-panel-block__item__header">
+            {{ 'UDF.NAME' | translate }}
+          </div>
+          <p class="cr-panel-block__item__content--full-width cr-panel--default">
+            {{ udf.label }}
+          </p>
+        </div>
+        <div class="udf-detail__cell">
+          <div class="cr-panel-block__item__header">
+            {{ 'UDF.PARAMETERS' | translate }}
+          </div>
+          <p class="cr-panel-block__item__content--full-width cr-panel--default">
+            {{ udf.input_types }}
+          </p>
+        </div>
+      </div>
+
+      <div class="udf-detail__row">
+        <div class="udf-detail__cell">
+          <div class="cr-panel-block__item__header">
+            {{ 'UDF.RETURN_TYPE' | translate }}
+          </div>
+          <p class="cr-panel-block__item__content--full-width cr-panel--default">
+            {{ udf.return_type }}
+          </p>
+        </div>
+        <div class="udf-detail__cell">
+          <div class="cr-panel-block__item__header">
+            {{ 'UDF.LANGUAGE' | translate }}
+          </div>
+          <p class="cr-panel-block__item__content--full-width cr-panel--default">
+            {{ udf.language }}
+          </p>
+        </div>
+      </div>
+      <div class="udf-detail__fullrow">
+        <div class="udf-detail__fullcell">
+          <div class="cr-panel-block__item__header">
+            {{ 'UDF.DEFINITION' | translate }}
+          </div>
+          <p class="cr-panel-block__item__content--full-width cr-panel--code">{{ udf.definition }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="query-table__panel">
+      <div id="execute-btn" class="cr-console-header__options__item--btn cr-button cr-button--console" ng-click="executeQuery(query)">
+        <div>{{ 'UDF.REPLACE_UDF' | translate }}</div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/udflist.html
+++ b/app/views/udflist.html
@@ -1,7 +1,7 @@
 <div class="side-bar table-side-bar" ng-show="renderSidebar">
 
   <div class="filter__wrapper">
-    <input id="tableFilter" ng-model="search" placeholder="Filter udfs ..." type="text" focus="true" />
+    <input id="tableFilter" ng-model="search" placeholder="Filter UDFs ..." type="text" focus="true" />
     <a ng-if="search" class="cr-clear-filters" ng-click="clearFilter()">
       <i class="fa fa-times-circle" aria-hidden="true"></i>
     </a>
@@ -31,7 +31,7 @@
            ng-class="{ 'active': isActive(udf.schema, udf.name)}"
            ng-if="renderSidebar"
            ng-repeat="udf in type.udfs | filter:udfFilter track by $index"
-           href="#!/udfs/{{ udf.schema }}/{{ udf.name }}">
+           href="#!/udfs/{{ udf.schema }}/{{ udf.name }}/{{udf.input_types}}">
            <div class="table-name-row">
             <div class="table-name">
               <h3>{{ udf.name }}</h3>

--- a/app/views/udflist.html
+++ b/app/views/udflist.html
@@ -1,0 +1,48 @@
+<div class="side-bar table-side-bar" ng-show="renderSidebar">
+
+  <div class="filter__wrapper">
+    <input id="tableFilter" ng-model="search" placeholder="Filter udfs ..." type="text" focus="true" />
+    <a ng-if="search" class="cr-clear-filters" ng-click="clearFilter()">
+      <i class="fa fa-times-circle" aria-hidden="true"></i>
+    </a>
+    <div>
+      <div ng-if="!collapsed" class="table__list__btn" ng-click="collapseAll()">
+        <img  class="collapse_btn" src="static/assets/icon-collapse-all.svg"/>
+      </div>
+      <div ng-if="collapsed" class="table__list__btn" ng-click="unCollapseAll()">
+        <img class="collapse_btn" src="static/assets/icon-expand-all.svg"/>
+      </div>
+    </div>
+  </div>
+
+  <div class="table-list-wrapper">
+    <div class="table-group" ng-repeat="type in udfs track by $index">
+
+      <div class="table__tab__header" id="table-nav-tab-header-{{$index}}" ng-class="isCollapsed($index) ? '' : 'table__tab__tab-header--selected'">
+        <div class="side-bar__header table__tab__header" ng-click="toggleElements($index)">
+          <i class="fa fa-caret-down" ng-class="{'fa-caret-down': !isCollapsed($index), 'fa-caret-right': isCollapsed($index)}"></i>
+          {{ type.display_name }} {{ 'UDF.TITLE' | translate }}</div>
+      </div>
+
+      <div id="table-side-bar-list--{{$index}}"
+            class="table-side-bar-list"
+            ng-class="{'collapse': isCollapsed($index), 'in': !isCollapsed($index)}">
+        <a class="side-bar__element tables-list__element"
+           ng-class="{ 'active': isActive(udf.schema, udf.name)}"
+           ng-if="renderSidebar"
+           ng-repeat="udf in type.udfs | filter:udfFilter track by $index"
+           href="#!/udfs/{{ udf.schema }}/{{ udf.name }}">
+           <div class="table-name-row">
+            <div class="table-name">
+              <h3>{{ udf.name }}</h3>
+            </div>
+          </div>
+          <div class="table-information">
+            <span>{{ udf.input_types }}</span>
+          </div>
+        </a>
+      </div>
+
+    </div>
+  </div>
+</div>

--- a/app/views/udfs.html
+++ b/app/views/udfs.html
@@ -5,7 +5,7 @@
       <div class="cr-panel-block">
         <p>
           <b>{{ 'UDF.VOID_MESSAGE' | translate }}</b>
-          <span translate="UDF.VOID_DETAILS" translate-values="{statement: '<a target=\'_blank\' href=\'https://crate.io/docs/crate/reference/en/latest/general/ddl/views.html\'>CREATE UDF</a>'}"></span>
+          <span translate="UDF.VOID_DETAILS" translate-values="{statement: '<a target=\'_blank\' href=\'https://crate.io/docs/crate/reference/en/latest/general/user-defined-functions.html\'>CREATE UDF</a>'}"></span>
         </p>
       </div>
     </div>

--- a/app/views/udfs.html
+++ b/app/views/udfs.html
@@ -1,0 +1,15 @@
+<div>
+  <div ng-class="$root.showSideList ? '' : 'hide-sidebar-list'">
+    <div class="page-container" ng-if="empty">
+      <h1 class="cr-page-header">{{ 'UDF.TITLE' | translate }}</h1>
+      <div class="cr-panel-block">
+        <p>
+          <b>{{ 'UDF.VOID_MESSAGE' | translate }}</b>
+          <span translate="UDF.VOID_DETAILS" translate-values="{statement: '<a target=\'_blank\' href=\'https://crate.io/docs/crate/reference/en/latest/general/ddl/views.html\'>CREATE UDF</a>'}"></span>
+        </p>
+      </div>
+    </div>
+    <udf-list ng-if="!empty"></udf-list>
+  </div>
+  <ui-view></ui-view>
+</div>


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Adding a view for User Defined Functions helps to manage and replace UDFs within CrateDB.
Before one would need to manually manage UDFs outside of CrateDB and/or remember queries like.

```sql
SELECT *
FROM information_schema.routines
WHERE routine_type = 'FUNCTION';
```

to check which UDFs exist within CrateDB

![image](https://user-images.githubusercontent.com/23557193/138554872-220be97e-a4d2-41d3-a82c-503b723ae90a.png)

forked from **Views**-view / section

Open To-Dos:
- [ ] Find or Create a suitable icon for sidebar
- [ ] Find a solution to translate internal data types like `integer_array` to `ARRAY(INTEGER)`
- [ ] Finish **Create or Replace** functionality
- [ ] Add correct translations (i18n)
- [ ] General cleanup (As this was derived from the views view)

closes #734

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
