### PR TITLE
Fixed duplicate entries in query history

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
   always shows last 15 minutes of QPS and query duration in 10 sec intervals.
   Slightly adjusted appearance of graphs.
 
+- Fixed duplicate entries in query history.
+
 
 2021-09-29 1.19.2
 =================

--- a/app/scripts/controllers/console.js
+++ b/app/scripts/controllers/console.js
@@ -191,7 +191,7 @@ const crate_console = angular.module('console', ['sql', 'datatypechecks', 'stats
           if ($scope.useLocalStorage) {
             getRecentQueriesFromLocalStorage();
           }
-          if (self.recentQueries[self.recentQueries.length -1] !== stmt) {
+          if (self.recentQueries[self.recentQueries.length -1] !== stmt + ';') {
             self.recentQueries.push(stmt + ';');
           }
           if ($scope.useLocalStorage) {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Fixed duplicate entries in query history.
Previously if the same query has been run multiple times in a row, for every execution an entry in the history has been made. Now there is only one entry independent of the number of query executions.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
