### PR TITLE
Update to crate-docs 2.1.0

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,21 +1,21 @@
-# Licensed to Crate (https://crate.io) under one or more contributor license
-# agreements.  See the NOTICE file distributed with this work for additional
-# information regarding copyright ownership.  Crate licenses this file to you
-# under the Apache License, Version 2.0 (the "License"); you may not use this
-# file except in compliance with the License.  You may obtain a copy of the
-# License at
+# Licensed to Crate.io GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-# License for the specific language governing permissions and limitations under
-# the License.
+# License for the specific language governing permissions and limitations
+# under the License.
 #
-# However, if you have executed another commercial license agreement with Crate
-# these terms will supersede the license and you may use the software solely
-# pursuant to the terms of the relevant commercial agreement.
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
 
 
 # =============================================================================
@@ -79,14 +79,14 @@ BUILD_JSON    := build.json
 BUILD_REPO    := https://github.com/crate/crate-docs.git
 LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
 CLONE_DIR     := .crate-docs
-SRC_DIR       := $(CLONE_DIR)/src
-SELF_SRC      := $(TOP_DIR)/src
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
 SELF_MAKEFILE := $(SELF_SRC)/rules.mk
 SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
 
 # Parse the JSON file
 BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
-    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["message"])')
 
 ifeq ($(BUILD_VERSION),)
 $(error No build version specified in `$(BUILD_JSON)`.)

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "1.0.0"
+  "message": "2.1.0"
 }


### PR DESCRIPTION
Will bring Sphinx 5 to the documentation sandbox.