### PR TITLE
Fix view list rendering issue which caused a jump to the default view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Unreleased
 
 - Updated a few JavaScript dependencies
 
+- Fixed an issue at the views tab where selecting a concrete view immediately
+  resulted in jumping back to the first view at the list.
+
+
 
 2022-06-21 1.22.1
 =================

--- a/app/scripts/controllers/views.js
+++ b/app/scripts/controllers/views.js
@@ -244,6 +244,7 @@ angular.module('views', ['stats', 'sql', 'common', 'viewinfo', 'events'])
           $scope.name = name;
           $scope.schema = schema;
           $scope.renderSidebar = true;
+          updateViewList();
         };
 
         ClusterEventsHandler.register('STATE_REFRESHED',


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

While rendering the view list, the `updateViewList()` must be called
to ensure that the previous selected view is used as the current
state may not be updated already.
This issue only happen when the selection is done fast while still
initializing the view tab.

Fixes #775.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
