### PR TITLE
Fit console query results in viewport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Console: Query results now fit within the view port, to make it easier to 
+  work with wide resultsets
+  
 
 2022-08-25 1.22.2
 =================
@@ -13,7 +16,6 @@ Unreleased
 
 - Fixed an issue at the views tab where selecting a concrete view immediately
   resulted in jumping back to the first view at the list.
-
 
 
 2022-06-21 1.22.1

--- a/app/styles/views/_common.scss
+++ b/app/styles/views/_common.scss
@@ -735,6 +735,10 @@ label:hover:before {
 	background: $block-border;
 }
 
+*::-webkit-scrollbar-corner {
+	background: $block-bg;
+}
+
 /* Works on Firefox */
 * {
 	scrollbar-width: thin;          /* "auto" or "thin" */

--- a/app/styles/views/_console.scss
+++ b/app/styles/views/_console.scss
@@ -159,9 +159,13 @@
 	border-left: 1px solid $block-border;
 	align-items: center;
 }
+
+.query-result-container .table-responsive {
+	max-height: 80vh;
+}
+
 .query-result-container .table-responsive thead,
-.query-result-container .table-responsive tbody,
-{
+.query-result-container .table-responsive tbody {
 	background: $block-bg;
 }
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- **Fit console query results in viewport**
  This should make it easier to work with wider result-sets, as one does not longer need to scroll to the bottom of the page to use the horizontal scrollbar
- **Fix: Adjust scrollbar corner color to fit with theme**
  was white before / didn't fit with rest of theme

<img width="2011" alt="image" src="https://user-images.githubusercontent.com/23557193/189523334-dfad123e-c006-4ec6-ba01-052c19723bf7.png">


## Checklist

 - [ x ] [CLA](https://crate.io/community/contribute/cla/) is signed
