### PR TITLE
Fixed formatting of timestamp values in console

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed formatting of ``TIMESTAMP WITHOUT TIME ZONE`` values in query console 
+  result table.
+
 
 2022-09-14 1.23.0
 =================

--- a/app/scripts/controllers/console.js
+++ b/app/scripts/controllers/console.js
@@ -262,6 +262,7 @@ const crate_console = angular.module('console', ['sql', 'datatypechecks', 'stats
 
               // Timestamp
             case 11:
+            case 15:
               return 'timestamp';
             case 12:
               return 'object';


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

- Fixed formatting of ``TIMESTAMP WITHOUT TIME ZONE`` values in query console 
  result table.

**_prev:_**
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/23557193/193026589-e7e174a5-22f9-4b98-ae0e-3873de04ec82.png">

**_now:_**
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/23557193/193026768-b5d7301f-218d-4db6-8a78-211264d476da.png">


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
