### PR TITLE
Sandbox/CI: Update to Node.js 18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ] #, macos-latest, windows-latest ]
-        node-version: [ '16' ]
+        node-version: [ '18' ]
 
     name: Node.js ${{ matrix.node-version }} on OS ${{ matrix.os }}
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,6 @@ pull_request_rules:
       queue:
         method: rebase
         name: default
-        rebase_fallback: none
 
   - name: Delete branch after merge
     actions:

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -13,11 +13,18 @@ Install Node.js locally::
     source .venv/bin/activate
     pip install -U pip
     pip install nodeenv
-    nodeenv --python-virtualenv --node=16.18.1
+    nodeenv --python-virtualenv --node=18.12.1
 
 Install the package dependencies::
 
     npm install
+
+Workaround::
+
+    # Mitigate `Error: error:0308010C:digital envelope routines::unsupported` on Node.js 18
+    # https://stackoverflow.com/a/69699772
+    # https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
+    export NODE_OPTIONS=--openssl-legacy-provider
 
 
 *****

--- a/package.json
+++ b/package.json
@@ -73,9 +73,9 @@
   },
   "scripts": {
     "cratedb": "docker run -it --rm --publish 4200:4200 crate/crate:nightly -Chttp.cors.enabled=true -Chttp.cors.allow-origin=*",
-    "develop": "webpack serve --progress --config=webpack.dev.config.js --open-target=http://localhost:9000/?base_uri=http://localhost:4200#!/",
-    "build": "webpack --config webpack.prod.config.js --progress",
-    "test": "karma start",
+    "develop": "NODE_OPTIONS=--openssl-legacy-provider webpack serve --progress --config=webpack.dev.config.js --open-target=http://localhost:9000/?base_uri=http://localhost:4200#!/",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.prod.config.js --progress",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider karma start",
     "postinstall": "node node_modules/phantomjs-prebuilt/install.js"
   }
 }


### PR DESCRIPTION
### About

Following up on #796, this patch updates the sandbox/build/CI environment to use Node.js 18.

### Caveats

`NODE_OPTIONS=--openssl-legacy-provider` was needed to satisfy `webpack@4`.

- [Error message "error:0308010C:digital envelope routines::unsupported"](https://stackoverflow.com/a/69699772)
- https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
- https://github.com/nodejs/node/issues/40455#issuecomment-1123071147

The real solution is to update to `webpack@5`.

- https://github.com/webpack/webpack/issues/14532#issuecomment-1324340823
