### PR TITLE
CI: Add an universal sandbox bootstrap program

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -7,24 +7,9 @@ Developer guide
 Setup
 *****
 
-Install Node.js locally::
+Install Node.js sandbox and package dependencies::
 
-    python3 -m venv .venv
-    source .venv/bin/activate
-    pip install -U pip
-    pip install nodeenv
-    nodeenv --python-virtualenv --node=18.12.1
-
-Install the package dependencies::
-
-    npm install
-
-Workaround::
-
-    # Mitigate `Error: error:0308010C:digital envelope routines::unsupported` on Node.js 18
-    # https://stackoverflow.com/a/69699772
-    # https://github.com/webpack/webpack/issues/14532#issuecomment-947012063
-    export NODE_OPTIONS=--openssl-legacy-provider
+    source bootstrap.sh
 
 
 *****
@@ -34,7 +19,6 @@ Tests
 To run the tests, use the following commands::
 
     npm test
-
 
 
 ***********************

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Install Node.js sandbox.
+export NODEJS_VERSION=18.12.1
+export NPM_VERSION=8.19.3
+source /dev/stdin <<<"$(curl -s https://raw.githubusercontent.com/cicerops/supernode/main/supernode)"
+
+# Install dependencies.
+npm install


### PR DESCRIPTION
The new `bootstrap.sh` is intended for both development and Jenkins, in order to fix https://github.com/crate/crate-alerts/issues/424.

_We need this because the sandbox environment of Admin UI got modernized to use Node.js 18 now, see https://github.com/crate/crate-admin/pull/797._