### PR TITLE
Fixed monitoring statement for compatibility with CrateDB 5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Fixed monitoring statement for compatibility with CrateDB 5.2,
+  ``AVG(ended - started)`` becomes ``AVG(ended::bigint - started::bigint)``.
+
 
 2023-02-15 1.24.2
 =================

--- a/app/scripts/controllers/overview.js
+++ b/app/scripts/controllers/overview.js
@@ -440,7 +440,7 @@ angular.module('overview', ['stats', 'checks', 'ngSanitize', 'events', 'filters_
       return 'SELECT CURRENT_TIMESTAMP AS last_timestamp, ' +
         '(ended / 10000) * 10000 + 5000 AS ended_time, ' +
         'COUNT(*) / 10.0 AS qps, ' +
-        'AVG(ended - started) AS duration, ' +
+        'AVG(ended::bigint - started::bigint) AS duration, ' +
         'UPPER(regexp_matches(stmt,\'^\\s*(\\w+).*\')[1]) AS query_type ' +
         'FROM sys.jobs_log ' +
         'WHERE ended > now() - (\'15 minutes\')::interval ' +

--- a/app/tests/services/monitoring/monitoringQueryService.test.js
+++ b/app/tests/services/monitoring/monitoringQueryService.test.js
@@ -47,7 +47,7 @@ describe('monitoring', function() {
       expect(stmt).toEqual('SELECT CURRENT_TIMESTAMP AS last_timestamp, ' +
       '(ended / 10000) * 10000 + 5000 AS ended_time, ' +
       'COUNT(*) / 10.0 AS qps, ' +
-      'AVG(ended - started) AS duration, ' +
+      'AVG(ended::bigint - started::bigint) AS duration, ' +
       'UPPER(regexp_matches(stmt,\'^\\s*(\\w+).*\')[1]) AS query_type ' +
       'FROM sys.jobs_log ' +
       'WHERE ended > now() - (\'15 minutes\')::interval ' +


### PR DESCRIPTION
CrateDB 5.2 needs `AVG(ended::bigint - started::bigint)` instead of `AVG(ended - started)`.