### PR TITLE
Fix additional whitespace in snapshot version (and readthedocs)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,15 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 sphinx:
   builder: html
   configuration: docs/conf.py
   fail_on_warning: true
 
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes for Crate Admin Interface
 Unreleased
 ==========
 
+- Removed a superfluous whitespace shown for CrateDB snapshot versions
+
 
 2023-07-05 1.24.4
 =================

--- a/app/views/statusbar.html
+++ b/app/views/statusbar.html
@@ -13,8 +13,7 @@
     <div class="status-bar__content__item hide-m">{{ 'STATUSBAR.VERSION' | translate }}:
       <div ng-if="version_warning " class="cr-bubble cr-bubble--danger"></div>
       <span ng-show="version" data-original-title="{{ versions.join('\n') }}" rel="tooltip">
-        {{ version.number }}
-        <span ng-show="version.snapshot">-{{ 'STATUSBAR.SNAPSHOT' | translate }}-{{ version.hash.substr(0,7) }}</span>
+        {{ version.number }}<span ng-show="version.snapshot">-{{ 'STATUSBAR.SNAPSHOT' | translate }}-{{ version.hash.substr(0,7) }}</span>
       </span>
     </div>
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.0"
+  "message": "2.1.1"
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Before:
<img width="267" alt="Screenshot 2023-10-19 at 15 55 20" src="https://github.com/crate/crate-admin/assets/218003/3cc69f90-88ea-4726-a60f-d30b52c36aa1">


After:
<img width="254" alt="Screenshot 2023-10-19 at 15 55 34" src="https://github.com/crate/crate-admin/assets/218003/ac97f594-a746-4d9c-b936-c928970ecb60">

Checked: Regular versions also still show successfully after the change
<img width="120" alt="Screenshot 2023-10-19 at 15 57 09" src="https://github.com/crate/crate-admin/assets/218003/d81e5dcd-7222-4418-a9b5-c40d87b86740">

## Checklist

 - [X] Link to issue this PR refers to (if applicable): 
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
