### PR TITLE
Disable leftover version chooser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,10 @@
 from crate.theme.rtd.conf.crate_admin_ui import *
 
 html_extra_path = []
+
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since there are no versions of this docs repo, we might as well remove the version chooser to make space for headlines.