### PR TITLE
Removed "--openssl-legacy-provider" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "scripts": {
     "cratedb": "docker run -it --rm --publish 4200:4200 crate/crate:nightly -Chttp.cors.enabled=true -Chttp.cors.allow-origin=*",
-    "develop": "NODE_OPTIONS=--openssl-legacy-provider webpack serve --progress --config=webpack.dev.config.js --open-target=http://localhost:9000/?base_uri=http://localhost:4200#!/",
-    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.prod.config.js --progress",
-    "test": "NODE_OPTIONS=--openssl-legacy-provider karma start"
+    "develop": "webpack serve --progress --config=webpack.dev.config.js --open-target=http://localhost:9000/?base_uri=http://localhost:4200#!/",
+    "build": "webpack --config webpack.prod.config.js --progress",
+    "test": "karma start"
   }
 }


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Removed unnecessary "--openssl-legacy-provider" argument, which was required for webpack@4
Now crate-admin successfully runs on windows after clean installation

Closes #846 

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
