### PR TITLE
Sandbox: Fix update to webpack 5

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -77,7 +77,6 @@ module.exports = {
         test: /\.(sa|sc|c)ss$/,
         use: [
           { loader: 'style-loader' },
-          { loader: MiniCssExtractPlugin.loader },
           { loader: 'css-loader', options: {} },
           { loader: 'sass-loader', options: {} },
         ]

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -75,7 +75,6 @@ module.exports = {
       {
         test: /\.(sa|sc|c)ss$/,
         use: [
-          { loader: 'style-loader' },
           { loader: MiniCssExtractPlugin.loader },
           { loader: 'css-loader', options: {} },
           { loader: 'sass-loader', options: {} },


### PR DESCRIPTION
## Problem
After updating to webpack 5, the build/test invocation introduced a few warnings.
- GH-861

## Solution
Follow the advice to not use `style-loader` and `mini-css-extract-loader` together.

- https://github.com/webpack-contrib/mini-css-extract-plugin/issues/613#issuecomment-707653736
