### PR TITLE
CI: Use both Node.js 20 and 22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,13 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest ] #, macos-latest, windows-latest ]
-        node-version: [ '22' ]
+        node-version: [
+          '20',
+          '22',
+        ]
 
     name: Node.js ${{ matrix.node-version }} on OS ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Mostly to check which builds faster on CI/GHA.
