### PR TITLE
Docs: index.rst: Minor page tuning

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,12 +21,6 @@ running locally, this will be ``localhost``.
 
 Navigate to this URL in a web browser.
 
-.. TIP::
-
-    If you access port ``4200`` via a client library or command-line tool
-    like ``curl`` or ``wget``, the request will be handled by the `CrateDB
-    Rest API`_, and the response will be in JSON.
-
 
 .. _index-navigating:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,16 +9,6 @@ CrateDB ships with a web administration user interface (or *Admin UI*).
 The CrateDB Admin UI runs on every CrateDB node. You can use it to inspect
 and interact with the whole CrateDB cluster in a number of ways.
 
-.. SEEALSO::
-
-   The CrateDB Admin UI is an open source project and is `hosted on GitHub`_.
-
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
 Connecting
 ==========
 
@@ -116,6 +106,11 @@ On the left-hand side, from top to bottom, the tabs are:
 - :ref:`Monitoring overview <monitoring-overview>`
 - :ref:`Privileges browser <privileges-browser>`
 - :ref:`Help screen <help-screen>`
+
+
+.. SEEALSO::
+
+   The CrateDB Admin UI is an open source project and is `hosted on GitHub`_.
 
 
 .. _Cluster name: https://crate.io/docs/crate/reference/en/latest/config/node.html#basics


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Overall the intent is to remove any "noise" that before getting started.

* GH admonition is secondary and is therefore moved to the bottom.
* The local TOC is removed as it's redundant with the local TOC being in the right navbar now.
* The Tip for using the Rest API isn't really so relevant here. If anything, we could consider it at the bottom, but why then not mention the CLI if it's alternatives we want to mention?
