### PR TITLE
Docs: remove in page toc

### DIFF
--- a/docs/cluster.rst
+++ b/docs/cluster.rst
@@ -7,24 +7,11 @@ Cluster browser
 The :ref:`CrateDB Admin UI <index>` comes with a *cluster browser* that allows
 you to inspect all of the nodes that are in your `cluster`_.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-.. _cluster-screenshots:
-
-Screenshots
-===========
-
-Here's what a single node cluster looks like:
-
 .. image:: _assets/img/cluster.png
 
-In this example, there is one node named *Monte Civetta*. When selected from
-the left-hand sub-navigation menu, information about a node is displayed.
-
+In this single node cluster example, there is one node named *Monte Civetta*.
+When selected from the left-hand sub-navigation menu, information about a node
+is displayed.
 
 .. _cluster-features:
 

--- a/docs/console.rst
+++ b/docs/console.rst
@@ -7,22 +7,12 @@ SQL console
 The :ref:`CrateDB Admin UI <index>` comes with an *SQL console* so that you can
 execute queries against your cluster directly from your web browser.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-.. _console-screenshots:
-
-Screenshots
-===========
-
 When you first load the console, it will look like this:
 
 .. image:: _assets/img/console-default.png
 
-And here's what the console looks like after executing a query:
+You can enter any SQL statement with autocompletion and syntax highlighting
+and see the result below:
 
 .. image:: _assets/img/console-query.png
 
@@ -31,16 +21,6 @@ And here's what the console looks like after executing a query:
 
 Features
 ========
-
-.. _console-syntax-highlighting:
-
-**Syntax highlighting**:
-  CrateDB SQL syntax highlighted as you type.
-
-.. _console-auto-completion:
-
-**Auto-completion**:
-  CrateDB SQL auto-completion makes suggestions as you type.
 
 .. _console-results-formatting:
 

--- a/docs/help.rst
+++ b/docs/help.rst
@@ -8,21 +8,4 @@ The :ref:`CrateDB Admin UI <index>` comes with a *help screen* that allows you
 to import some tweets for testing purposes. This screen also includes links to
 important CrateDB support resources.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-Screenshot
-==========
-
 .. image:: _assets/img/help.png
-
-
-.. _help-features:
-
-Features
-========
-
-This page includes links to various help resources.

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -7,17 +7,6 @@ Monitoring overview
 The :ref:`CrateDB Admin UI <index>` comes with a *monitoring overview* screen
 that allows you to monitor key operational statistics.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-.. _monitoring-screenshots:
-
-Screenshots
-===========
-
 .. image:: _assets/img/monitoring.png
 
 The monitoring page has two live charts:

--- a/docs/privileges.rst
+++ b/docs/privileges.rst
@@ -7,17 +7,6 @@ Privileges browser
 The :ref:`CrateDB Admin UI <index>` comes with a *privileges browser* that
 allows you to inspect `users`_ and `privileges`_.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-.. _privileges-screenshots:
-
-Screenshots
-===========
-
 When you first visit the privileges browser, the ``crate`` superuser will be
 selected:
 

--- a/docs/shards.rst
+++ b/docs/shards.rst
@@ -7,21 +7,9 @@ Shards browser
 The :ref:`CrateDB Admin UI <index>` comes with a *shards browser* that
 provides you with a visual overview of all the `shards`_ in your cluster.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-.. _shards-screenshots:
-
-Screenshots
-===========
-
-Here's what a simple database might look like:
-
 .. image:: _assets/img/shards.png
 
-In this example, there is one primary column:
+In the example above, there is one primary column:
 
  - The *blob* column holds `BLOB tables`_
 

--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -7,20 +7,6 @@ Tables browser
 The :ref:`CrateDB Admin UI <index>` comes with a *tables browser* that allows
 you to inspect and query regular `document tables`_ as well as `BLOB tables`_.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-
-.. _tables-screenshots:
-
-Screenshots
-===========
-
-Here's what a simple document table looks like:
-
 .. image:: _assets/img/tables.png
 
 The top section on this screen shows you a basic :ref:`overview

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -7,19 +7,6 @@ Views browser
 The :ref:`CrateDB Admin UI <index>` comes with a *views browser* that allows
 you to inspect and query stored `views`_.
 
-.. rubric:: Table of contents
-
-.. contents::
-   :local:
-
-
-.. _views-screenshots:
-
-Screenshots
-===========
-
-Here's what a simple view looks like:
-
 .. image:: _assets/img/views.png
 
 The top section on this screen shows you a basic :ref:`overview


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
The in-page TOC is redundant as it's also present to the right side.
"Screenshot" headline seems a bit silly, so removed that.

